### PR TITLE
Feat/courtCreate/addNewCourtInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "@emotion/styled": "^11.6.0",
     "axios": "^0.24.0",
     "feather-icons": "^4.28.0",
+    "framer-motion": "^5.3.3",
     "next": "12.0.4",
     "react": "17.0.2",
     "react-dom": "^17.0.2",
+    "react-modal-sheet": "^1.4.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/components/KakaoMap/index.tsx
+++ b/src/components/KakaoMap/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, CSSProperties } from "react";
 import type { ReactNode } from "react";
 import { DEFAULT_POSITION } from "@utils/geolocation";
 import { useMapContext } from "@contexts/MapProvider";
@@ -14,17 +14,23 @@ declare global {
 interface Props {
   level: number;
   center: Coord;
+  draggable?: boolean;
+  zoomable?: boolean;
   onClick: (_: kakao.maps.Map, event: kakao.maps.event.MouseEvent) => void;
-  onDragEnd: (_: kakao.maps.Map) => void;
+  onDragEnd?: (_: kakao.maps.Map) => void;
   children: ReactNode;
+  style?: CSSProperties;
 }
 
 const KakaoMap = ({
   level,
   center,
+  draggable = true,
+  zoomable = true,
   onClick,
   onDragEnd,
   children,
+  style,
 }: Props): JSX.Element => {
   const { map, handleInitMap } = useMapContext();
   const mapRef = useRef<HTMLDivElement>(null);
@@ -40,6 +46,18 @@ const KakaoMap = ({
       map.setLevel(level);
     }
   }, [map, level]);
+
+  useEffect(() => {
+    if (map) {
+      map.setDraggable(draggable);
+    }
+  }, [map, draggable]);
+
+  useEffect(() => {
+    if (map) {
+      map.setZoomable(zoomable);
+    }
+  }, [map, zoomable]);
 
   useEffect(() => {
     if (!mapRef.current) {
@@ -62,7 +80,7 @@ const KakaoMap = ({
 
   return (
     <>
-      <div ref={mapRef} style={{ width: "100%", height: "100%" }}>
+      <div ref={mapRef} style={{ width: "100%", height: "100%", ...style }}>
         현재 위치를 받아오는 중입니다.
         {children}
       </div>

--- a/src/components/base/Input/index.tsx
+++ b/src/components/base/Input/index.tsx
@@ -1,0 +1,21 @@
+import { HTMLAttributes } from "react";
+import Text from "../Text";
+
+interface Props extends HTMLAttributes<HTMLInputElement> {
+  label: string;
+  type: string;
+  name: string;
+  block?: boolean;
+  [x: string]: any;
+}
+
+const Input = ({ label, block, ...props }: Props) => (
+  <div>
+    <label>
+      <Text block={block}>{label}</Text>
+      <input {...props}></input>
+    </label>
+  </div>
+);
+
+export default Input;

--- a/src/contexts/NavigationProvider/actionTypes.ts
+++ b/src/contexts/NavigationProvider/actionTypes.ts
@@ -10,4 +10,5 @@ export const pageType = {
   MAP: "MAP",
   BOOK: "BOOK",
   ACTIVITY: "ACTIVITY",
+  COURT_CREATE: "COURT_CREATE",
 } as const;

--- a/src/contexts/NavigationProvider/reducer.ts
+++ b/src/contexts/NavigationProvider/reducer.ts
@@ -105,6 +105,20 @@ export const reducer: Reducer<DataProps, ReducerAction> = (
         title: "로그인",
       };
     }
+    case pageType.COURT_CREATE: {
+      return {
+        ...state,
+        isTopNavigation: true,
+        isBottomNavigation: true,
+        currentPage: type,
+        isBack: true,
+        isNotifications: true,
+        isProfile: true,
+        isNext: false,
+        isMenu: false,
+        title: "새 농구장 추가",
+      };
+    }
     default: {
       return { ...state };
     }

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -3,12 +3,12 @@ import { ChangeEvent, FormEvent, useState } from "react";
 interface UseFormArgs<T> {
   initialValues: T;
   onSubmit: (values: T) => void;
-  validate: (values: T) => T;
+  validate: (values: T) => Partial<T>;
 }
 
 const useForm = <T>({ initialValues, onSubmit, validate }: UseFormArgs<T>) => {
   const [values, setValues] = useState<T>(initialValues);
-  const [errors, setErrors] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<{ [P in keyof T]?: T[P] }>({});
   const [isLoading, setIsLoading] = useState(false);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -19,8 +19,7 @@ const useForm = <T>({ initialValues, onSubmit, validate }: UseFormArgs<T>) => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     setIsLoading(true);
     e.preventDefault();
-    console.log("hi");
-    const newErrors = validate ? validate(values) : initialValues;
+    const newErrors = validate ? validate(values) : {};
     if (Object.keys(newErrors).length === 0) {
       await onSubmit(values);
     }

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,14 +1,16 @@
 import { ChangeEvent, FormEvent, useState } from "react";
 
+export type Error<T> = { [P in keyof T]?: string };
+
 interface UseFormArgs<T> {
   initialValues: T;
   onSubmit: (values: T) => void;
-  validate: (values: T) => Partial<T>;
+  validate: (values: T) => Error<T>;
 }
 
 const useForm = <T>({ initialValues, onSubmit, validate }: UseFormArgs<T>) => {
   const [values, setValues] = useState<T>(initialValues);
-  const [errors, setErrors] = useState<{ [P in keyof T]?: T[P] }>({});
+  const [errors, setErrors] = useState<Error<T>>({});
   const [isLoading, setIsLoading] = useState(false);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/court/create.tsx
+++ b/src/pages/court/create.tsx
@@ -4,31 +4,90 @@ import Text from "@components/base/Text";
 import Button from "@components/Button";
 import type { NextPage } from "next";
 import Head from "next/head";
+import useForm from "../../hooks/useForm";
+
+interface Values {
+  longitude: number;
+  latitude: number;
+  image: string | null;
+  texture: string | null;
+  basketCount: string; // TODO: 백엔드에 string으로 수정 요청
+  courtName: string;
+}
 
 const createCourt: NextPage = () => {
+  const { values, errors, isLoading, handleChange, handleSubmit } =
+    useForm<Values>({
+      initialValues: {
+        longitude: 0,
+        latitude: 0,
+        image: null,
+        texture: null,
+        basketCount: "1",
+        courtName: "",
+      },
+      onSubmit: (values) => {
+        alert(JSON.stringify(values));
+      },
+      validate: ({
+        // longitude,
+        // latitude,
+        // image,
+        // texture,
+        basketCount,
+        courtName,
+      }) => {
+        const errors: Partial<Values> = {};
+
+        if (!courtName) {
+          errors.courtName = "농구장 이름을 입력해주세요.";
+        }
+        if (!basketCount) {
+          errors.basketCount = "골대 개수를 입력해주세요.";
+        }
+
+        return errors;
+      },
+    });
+
   return (
     <div>
       <Head>
         <title>새 농구장 추가</title>
       </Head>
-      <form>
+
+      <form onSubmit={handleSubmit}>
         <Spacer size={24} type="vertical">
-          <Input label="농구장 이름" type="text" name="courtName" block />
-          <Text>위치</Text>
-          <div
-            style={{ width: "100%", height: "200px", background: "lightblue" }}
-          >
-            지도 맵 영역
+          <div>
+            <Input
+              label="농구장 이름"
+              type="text"
+              name="courtName"
+              onChange={handleChange}
+              value={values.courtName}
+            />
+            <span>{errors.courtName}</span>
           </div>
-          <Input
-            label="골대 개수"
-            type="number"
-            name="courtCount"
-            min="0"
-            max="100"
-            required
-          />
-          <Button type="submit">제출하기</Button>
+          <div>
+            <Text>위치</Text>
+            <Button type="button" onClick={() => alert("//TODO: 모달 띄우기")}>
+              지도 맵 영역
+            </Button>
+          </div>
+          <div>
+            <Input
+              label="골대 개수"
+              type="number"
+              name="courtCount"
+              min="0"
+              max="100"
+              onChange={handleChange}
+              value={values.basketCount}
+              required
+            />
+            <span>{errors.basketCount}</span>
+          </div>
+          <Button type="submit">{isLoading ? "Loading..." : "제출하기"}</Button>
         </Spacer>
       </form>
     </div>

--- a/src/pages/court/create.tsx
+++ b/src/pages/court/create.tsx
@@ -1,0 +1,38 @@
+import Input from "@components/base/Input";
+import Spacer from "@components/base/Spacer";
+import Text from "@components/base/Text";
+import Button from "@components/Button";
+import type { NextPage } from "next";
+import Head from "next/head";
+
+const createCourt: NextPage = () => {
+  return (
+    <div>
+      <Head>
+        <title>새 농구장 추가</title>
+      </Head>
+      <form>
+        <Spacer size={24} type="vertical">
+          <Input label="농구장 이름" type="text" name="courtName" block />
+          <Text>위치</Text>
+          <div
+            style={{ width: "100%", height: "200px", background: "lightblue" }}
+          >
+            지도 맵 영역
+          </div>
+          <Input
+            label="골대 개수"
+            type="number"
+            name="courtCount"
+            min="0"
+            max="100"
+            required
+          />
+          <Button type="submit">제출하기</Button>
+        </Spacer>
+      </form>
+    </div>
+  );
+};
+
+export default createCourt;

--- a/src/pages/court/create.tsx
+++ b/src/pages/court/create.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import Input from "@components/base/Input";
 import Spacer from "@components/base/Spacer";
 import Text from "@components/base/Text";
@@ -7,6 +7,8 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import Sheet from "react-modal-sheet";
 import KakaoMap from "@components/KakaoMap";
+import styled from "@emotion/styled";
+import { DEFAULT_POSITION } from "@utils/geolocation";
 import useForm from "../../hooks/useForm";
 
 interface Values {
@@ -19,6 +21,22 @@ interface Values {
 }
 
 const createCourt: NextPage = () => {
+  const [isOpen, setOpen] = useState(false);
+  const [level, setLevel] = useState<number>(3);
+  const [center, setCenter] = useState<Coord>(DEFAULT_POSITION);
+  const [position, setPosition] = useState<Coord>();
+
+  const onClick = (
+    _: kakao.maps.Map,
+    mouseEvent: kakao.maps.event.MouseEvent
+  ) => {
+    const { latLng } = mouseEvent;
+
+    if (latLng) {
+      setPosition([latLng.getLat(), latLng.getLng()]);
+    }
+  };
+
   const { values, errors, isLoading, handleChange, handleSubmit } =
     useForm<Values>({
       initialValues: {
@@ -53,8 +71,6 @@ const createCourt: NextPage = () => {
       },
     });
 
-  const [isOpen, setOpen] = useState(false);
-
   return (
     <div>
       <Head>
@@ -75,9 +91,17 @@ const createCourt: NextPage = () => {
           </div>
           <div>
             <Text>위치</Text>
-            <Button type="button" onClick={() => setOpen(true)}>
-              지도 맵 영역
-            </Button>
+            <MapContainer>
+              {values.longitude && values.latitude ? (
+                <KakaoMap level={level} center={center} />
+              ) : (
+                <div>
+                  <button type="button" onClick={() => setOpen(true)}>
+                    지도 맵 영역
+                  </button>
+                </div>
+              )}
+            </MapContainer>
           </div>
           <div>
             <Input
@@ -96,25 +120,55 @@ const createCourt: NextPage = () => {
         </Spacer>
       </form>
 
-      <Sheet
+      <CustomSheet
         isOpen={isOpen}
         disableDrag={true}
-        springConfig={{ stiffness: 500, damping: 50 }}
+        springConfig={{ from: 0 }}
         onClose={() => setOpen(false)}
       >
         <Sheet.Container>
-          <Sheet.Header />
           <Sheet.Content>
-            <KakaoMap></KakaoMap>
-            <Button type="button" onClick={() => setOpen(false)}>
-              모달 끄기
-            </Button>
+            {/* <KakaoMap></KakaoMap> */}
+            <div style={{ height: "70%" }}>모달</div>
+            <button type="button" onClick={() => setOpen(false)}>
+              저장하기
+            </button>
           </Sheet.Content>
         </Sheet.Container>
-        <Sheet.Backdrop />
-      </Sheet>
+      </CustomSheet>
     </div>
   );
 };
 
 export default createCourt;
+
+const MapContainer = styled.div`
+  width: 100%;
+  height: 100px;
+
+  & > div {
+    width: 100%;
+    height: 100%;
+    background-image: url("https://user-images.githubusercontent.com/84858773/144864259-1d91a4b2-937c-441d-bb96-22758ab90294.png");
+    background-size: cover;
+    background-position: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    filter: contrast(70%);
+  }
+`;
+
+const CustomSheet = styled(Sheet)`
+  max-width: 640px;
+  margin: auto;
+
+  .react-modal-sheet-container {
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    background-color: #fafafa !important;
+    height: 100vh !important;
+  }import { DEFAULT_POSITION } from '@utils/geolocation';
+import { DEFAULT_POSITION } from '@utils/geolocation';
+
+`;

--- a/src/pages/court/create.tsx
+++ b/src/pages/court/create.tsx
@@ -39,6 +39,9 @@ interface Geocoder extends kakao.maps.services.Geocoder {
 const CreateCourt: NextPage = () => {
   const { map } = useMapContext();
 
+  const { useMountPage } = useNavigationContext();
+  useMountPage((page) => page.COURT_CREATE);
+
   const [isOpen, setOpen] = useState(false);
   const [isAddressLoading, setIsAddressLoading] = useState<boolean>(false);
   const [level, setLevel] = useState<number>(3);

--- a/src/pages/court/create.tsx
+++ b/src/pages/court/create.tsx
@@ -1,9 +1,12 @@
+import { useState } from "react";
 import Input from "@components/base/Input";
 import Spacer from "@components/base/Spacer";
 import Text from "@components/base/Text";
 import Button from "@components/Button";
 import type { NextPage } from "next";
 import Head from "next/head";
+import Sheet from "react-modal-sheet";
+import KakaoMap from "@components/KakaoMap";
 import useForm from "../../hooks/useForm";
 
 interface Values {
@@ -50,6 +53,8 @@ const createCourt: NextPage = () => {
       },
     });
 
+  const [isOpen, setOpen] = useState(false);
+
   return (
     <div>
       <Head>
@@ -70,7 +75,7 @@ const createCourt: NextPage = () => {
           </div>
           <div>
             <Text>위치</Text>
-            <Button type="button" onClick={() => alert("//TODO: 모달 띄우기")}>
+            <Button type="button" onClick={() => setOpen(true)}>
               지도 맵 영역
             </Button>
           </div>
@@ -90,6 +95,24 @@ const createCourt: NextPage = () => {
           <Button type="submit">{isLoading ? "Loading..." : "제출하기"}</Button>
         </Spacer>
       </form>
+
+      <Sheet
+        isOpen={isOpen}
+        disableDrag={true}
+        springConfig={{ stiffness: 500, damping: 50 }}
+        onClose={() => setOpen(false)}
+      >
+        <Sheet.Container>
+          <Sheet.Header />
+          <Sheet.Content>
+            <KakaoMap></KakaoMap>
+            <Button type="button" onClick={() => setOpen(false)}>
+              모달 끄기
+            </Button>
+          </Sheet.Content>
+        </Sheet.Container>
+        <Sheet.Backdrop />
+      </Sheet>
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import Button from "@components/Button";
 import { useNavigationContext } from "@contexts/NavigationProvider";
+import Link from "next/link";
 
 const Home: NextPage = () => {
   const { useMountPage } = useNavigationContext();
@@ -15,6 +16,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <h1>홈 페이지</h1>
+      <Link href="/court/create">새 농구장 추가</Link>
       <Button>Click Me!</Button>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,12 +261,24 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.1.tgz#cbd843d409dfaad90f9404e7c0404c55eae8c134"
   integrity sha512-bW1Tos67CZkOURLc0OalnfxtSXQJMrAMV0jZTVGJUPSOd4qgjF3+tTD5CwJM13PHA8cltGW1WGbbvV9NpvUZPw==
   dependencies:
     "@emotion/memoize" "^0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
   version "0.7.5"
@@ -2363,6 +2375,33 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+  
+framer-motion@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-5.3.3.tgz#366fa11512de4e79e061eb09a68278dad92b4419"
+  integrity sha512-s4mz0E4/TPTKXqKnpb578S0Jp/0JhAyvDpULFe95kHnWs1lOCKf2+EEl6yAX+1wfPLUYokZzudiK9jam0ZAVdQ==
+  dependencies:
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    popmotion "11.0.0"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
+  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
+  dependencies:
+    tslib "^2.1.0"
+
+framesync@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.1.0.tgz#b22cf9afba52a9a895668b09e033b6a61e901c41"
+  integrity sha512-aBX+hdWAvwiJYeQlFLY2533VxeL6OEu71CAgV4GGKksrj6+dE6i7K86WSSiRBEARCoJn5bFqffhg4l07eA27tg==
+  dependencies:
+    tslib "^2.3.1"
 
 fs-extra@^10.0.0:
   version "10.0.0"
@@ -2623,6 +2662,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -3973,6 +4017,16 @@ platform@1.3.6:
   resolved "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
+popmotion@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.0.tgz#910e2e7077d9aeba520db8744d40bb5354992212"
+  integrity sha512-kJDyaG00TtcANP5JZ51od+DCqopxBm2a/Txh3Usu23L9qntjY5wumvcVf578N8qXEHR1a+jx9XCv8zOntdYalQ==
+  dependencies:
+    framesync "^6.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+
 postcss@8.2.15:
   version "8.2.15"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz"
@@ -4145,6 +4199,18 @@ react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-merge-refs@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
+react-modal-sheet@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-modal-sheet/-/react-modal-sheet-1.4.1.tgz#b2de2b1b3ceb4a600c2fd1213c4846aab5c9948f"
+  integrity sha512-cI7bU3R59p9yxpyzSz7dRCnHvLZTh+8i/FAxz2DyL/a22bUG9hvOgDBmRlIP0ko5BPjyTM8bZBguHy7bMShfmg==
+  dependencies:
+    react-merge-refs "1.1.0"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -4774,6 +4840,14 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+  
+style-value-types@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
+  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^2.1.0"
 
 styled-jsx@5.0.0-beta.3:
   version "5.0.0-beta.3"
@@ -4971,7 +5045,7 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2:
+tslib@^2, tslib@^2.1.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
유저가 새 농구장 정보를 추가할 수 있는 페이지를 구현했습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #8 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- 🙏 모달창의 맵에서 특정 위치를 클릭하고 저장 버튼을 누르면 새 농구장 정보 작성 페이지에서도 지도를 통해 저장한 위치를 보여줄 수 있도록 구현했는데요. 이 페이지에서 KakaoMap 컴포넌트를 2개 사용하고 있어서 KakaoMap 컴포넌트 간에 센터값을 제대로 전달하지 못하는 문제가 있었습니다. 아까 한나랑 같이 뭐가 문제인지 찾았는데 제가 집에 와서 수정하려고 보니 수정이 안 되더라고요 😭 우선 JSX 코드 부분에서 form과 모달 Sheet 순서를 바꿔놓아서 기능은 구현되도록 해뒀는데요. 조속히 해결해보도록 할게요 🙏
- 위치 정보는 모달창에서 받을 수 있도록 구현했습니다. (맵에서의 드래그 이벤트와 겹치기 때문에 모달은 드래그 불가능하게 설정했습니다) 
- 임시로 홈에 새 농구장 추가 페이지로 진입할 수 있는 링크를 넣어두었습니다.
- useForm 커스텀 훅을 수정했습니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/84858773/145085147-86c37021-93e3-4b4d-8152-560ca4b93f84.png)
![image](https://user-images.githubusercontent.com/84858773/145085267-99040a0c-3134-4a64-9c81-0f2cfb1f3afe.png)
![image](https://user-images.githubusercontent.com/84858773/145085315-23ab55ea-cac7-4625-bac2-f2eff7c2d7c0.png)
![image](https://user-images.githubusercontent.com/84858773/145085448-3299e729-0003-47a4-9efb-8d4b1dc6bb5c.png)
