### PR TITLE
✨feat: 사용자정보 request시 로띠 활용 400ms 페이드아웃 로딩

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
     "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "^17.0.2",
+    "react-lottie": "^1.2.3",
     "react-modal-sheet": "^1.4.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^4.0.0-beta.12",
     "@types/feather-icons": "^4.7.0",
     "@types/node": "16.11.10",
     "@types/react": "17.0.37",
     "@types/react-dom": "^17.0.11",
+    "@types/react-lottie": "^1.2.6",
     "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
@@ -41,8 +44,7 @@
     "kakao.maps.d.ts": "^0.1.24",
     "lint-staged": ">=10",
     "prettier": "^2.5.0",
-    "typescript": "4.5.2",
-    "@netlify/plugin-nextjs": "^4.0.0-beta.12"
+    "typescript": "4.5.2"
   },
   "lint-staged": {
     "*.{ts,tsx,js}": "eslint --cache --fix",

--- a/src/UtilRoute/index.tsx
+++ b/src/UtilRoute/index.tsx
@@ -37,8 +37,6 @@ const UtilRouteHOCWrapper = ({
   useEffect(() => {
     const { pathname } = router;
 
-    console.log(pathname);
-
     switch (option) {
       case routeOption.private:
         if (localToken) {

--- a/src/components/domain/AuthLoading.tsx
+++ b/src/components/domain/AuthLoading.tsx
@@ -1,10 +1,11 @@
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
+import styled from "@emotion/styled";
 import Lottie from "react-lottie";
+import { useAuthContext } from "@contexts/hooks";
 import * as animationData from "../../../public/assets/lottie/basketball.json";
 
-const width = 13;
-const fadeoutTimeMs = 400;
+const WIDTH = 13;
+const FADE_OUT_TIME_MS = 400;
 
 const defaultOptions = {
   loop: true,
@@ -15,30 +16,25 @@ const defaultOptions = {
   },
 };
 
-interface Props {
-  isShow: boolean;
-}
+const AuthLoading = () => {
+  const { authProps } = useAuthContext();
+  const { isLoading } = authProps;
 
-const AuthLoading = ({ isShow }: Props) => {
   const [isDisplay, setIsDisplay] = useState(true);
 
-  const getHeight = (width: number) => width * 1.32;
-
   useEffect(() => {
-    if (!isShow) {
-      setTimeout(() => setIsDisplay(false), fadeoutTimeMs);
+    if (isLoading) {
+      setIsDisplay(true);
+    } else {
+      setTimeout(() => setIsDisplay(false), FADE_OUT_TIME_MS);
     }
-  }, [isShow]);
+  }, [isLoading]);
 
   return isDisplay ? (
-    <LoadingContainer isShow={isShow}>
+    <LoadingContainer isShow={isLoading}>
       <LogoWrapper>
         <LogoText>Slam</LogoText>
-        <Lottie
-          options={defaultOptions}
-          height={getHeight(width)}
-          width={width}
-        />
+        <Lottie options={defaultOptions} width={WIDTH} />
       </LogoWrapper>
     </LoadingContainer>
   ) : (
@@ -59,7 +55,7 @@ const LoadingContainer = styled.div<{ isShow: boolean }>`
   backdrop-filter: blur(8px);
 
   // 애니메이션
-  transition: all ${fadeoutTimeMs}ms ease-out;
+  transition: all ${FADE_OUT_TIME_MS}ms ease-out;
   opacity: ${({ isShow }) => (isShow ? 1 : 0)};
 `;
 
@@ -73,7 +69,7 @@ const LogoText = styled.span`
   font-size: 30px;
   font-family: "Righteous", sans-serif;
   font-weight: 900;
-  margin-bottom: 6px;
+  margin-bottom: 13px;
   margin-right: 2px;
 `;
 

--- a/src/components/domain/BottomNavigtion/index.tsx
+++ b/src/components/domain/BottomNavigtion/index.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import React from "react";
 import Link from "next/link";
-import { useNavigationContext } from "@contexts/NavigationProvider";
 import { Icon } from "@components/base";
+import { useNavigationContext } from "@contexts/hooks";
 
 const BottomNavigation = () => {
   const {

--- a/src/components/domain/TopNavigation/index.tsx
+++ b/src/components/domain/TopNavigation/index.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useNavigationContext } from "@contexts/NavigationProvider";
 import { Icon, Avatar, Badge } from "@components/base";
 import { useRouter } from "next/router";
+import { useAuthContext } from "@contexts/AuthProvider";
 
 interface Props {
   isTransparent: boolean;
@@ -11,6 +12,11 @@ interface Props {
 
 const TopNavigation = forwardRef<HTMLElement, Props>(
   ({ isTransparent }, ref) => {
+    const {
+      authProps: { currentUser },
+    } = useAuthContext();
+    const { userId, profileImageUrl } = currentUser;
+
     const {
       navigationProps: {
         isBack,
@@ -27,9 +33,6 @@ const TopNavigation = forwardRef<HTMLElement, Props>(
 
     const handleDefaultBack = () => {
       router.back();
-    };
-    const handleDefaultNext = () => {
-      console.log("다음버튼을 눌렀습니다. 기본 다음 버튼 이벤트가 실행됩니다.");
     };
 
     return (
@@ -55,11 +58,16 @@ const TopNavigation = forwardRef<HTMLElement, Props>(
               </Badge>
             )}
             {isProfile && (
-              <Link href={`/user/${1}`}>
+              <Link
+                href={`/user/${
+                  1 || userId // TODO:  나중에 로그인이 안정화 되면 1대신 userId 넣자
+                }`}
+              >
                 <a>
                   <Avatar
                     size={32}
                     src={
+                      profileImageUrl ||
                       "https://upload.wikimedia.org/wikipedia/commons/8/89/Portrait_Placeholder.png"
                     }
                   />
@@ -75,9 +83,7 @@ const TopNavigation = forwardRef<HTMLElement, Props>(
             )}
 
             {customButton && (
-              <CustomButton
-                onClick={customButton.handleClick || handleDefaultNext}
-              >
+              <CustomButton onClick={customButton.handleClick}>
                 {customButton.title}
               </CustomButton>
             )}

--- a/src/components/domain/TopNavigation/index.tsx
+++ b/src/components/domain/TopNavigation/index.tsx
@@ -1,10 +1,9 @@
 import React, { forwardRef } from "react";
 import styled from "@emotion/styled";
 import Link from "next/link";
-import { useNavigationContext } from "@contexts/NavigationProvider";
 import { Icon, Avatar, Badge } from "@components/base";
 import { useRouter } from "next/router";
-import { useAuthContext } from "@contexts/AuthProvider";
+import { useAuthContext, useNavigationContext } from "@contexts/hooks";
 
 interface Props {
   isTransparent: boolean;

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -3,3 +3,4 @@ export { default as BottomNavigation } from "./BottomNavigtion";
 export { default as KakaoLogin } from "./KakaoLogin";
 export { default as DatePicker } from "./DatePicker";
 export { default as SlotPicker } from "./SlotPicker";
+export { default as AuthLoading } from "./AuthLoading";

--- a/src/components/layout/DefaultLayout/index.tsx
+++ b/src/components/layout/DefaultLayout/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { useNavigationContext } from "@contexts/NavigationProvider";
 import { BottomNavigation, TopNavigation } from "@components/domain";
+import { useNavigationContext } from "@contexts/hooks";
 import Container from "./Container";
 
 interface Props {
@@ -9,14 +9,13 @@ interface Props {
 }
 
 const DefaultLayout = ({ children }: Props) => {
+  const { navigationProps } = useNavigationContext();
+  const { isBottomNavigation, isTopNavigation } = navigationProps;
+
   const [isTransparent, setIsTransparent] = useState(true);
 
   const topNavigationRef = useRef<HTMLElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const {
-    navigationProps: { isBottomNavigation, isTopNavigation },
-  } = useNavigationContext();
 
   const handleScroll = () =>
     topNavigationRef.current &&

--- a/src/contexts/AuthProvider/AuthLoading.tsx
+++ b/src/contexts/AuthProvider/AuthLoading.tsx
@@ -1,0 +1,80 @@
+import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import Lottie from "react-lottie";
+import * as animationData from "../../../public/assets/lottie/basketball.json";
+
+const width = 13;
+const delay = 200;
+
+const defaultOptions = {
+  loop: true,
+  autoplay: true,
+  animationData,
+  rendererSettings: {
+    preserveAspectRatio: "xMidYMid slice",
+  },
+};
+
+interface Props {
+  isShow: boolean;
+}
+
+const AuthLoading = ({ isShow }: Props) => {
+  const [isDisplay, setIsDisplay] = useState(true);
+
+  const getHeight = (width: number) => width * 1.32;
+
+  useEffect(() => {
+    if (!isShow) {
+      setTimeout(() => setIsDisplay(false), delay);
+    }
+  }, [isShow]);
+
+  return isDisplay ? (
+    <LoadingContainer isShow={isShow}>
+      <LogoWrapper>
+        <LogoText>Slam</LogoText>
+        <Lottie
+          options={defaultOptions}
+          height={getHeight(width)}
+          width={width}
+        />
+      </LogoWrapper>
+    </LoadingContainer>
+  ) : (
+    <></>
+  );
+};
+
+const LoadingContainer = styled.div<{ isShow: boolean }>`
+  pointer-events: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  z-index: 9999;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(8px);
+
+  // 애니메이션
+  transition: all ${delay}ms ease-out;
+  opacity: ${({ isShow }) => (isShow ? 1 : 0)};
+`;
+
+const LogoWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LogoText = styled.span`
+  font-size: 30px;
+  font-family: "Righteous", sans-serif;
+  font-weight: 900;
+  margin-bottom: 6px;
+  margin-right: 2px;
+`;
+
+export default AuthLoading;

--- a/src/contexts/AuthProvider/AuthLoading.tsx
+++ b/src/contexts/AuthProvider/AuthLoading.tsx
@@ -4,7 +4,7 @@ import Lottie from "react-lottie";
 import * as animationData from "../../../public/assets/lottie/basketball.json";
 
 const width = 13;
-const delay = 200;
+const fadeoutTimeMs = 400;
 
 const defaultOptions = {
   loop: true,
@@ -26,7 +26,7 @@ const AuthLoading = ({ isShow }: Props) => {
 
   useEffect(() => {
     if (!isShow) {
-      setTimeout(() => setIsDisplay(false), delay);
+      setTimeout(() => setIsDisplay(false), fadeoutTimeMs);
     }
   }, [isShow]);
 
@@ -59,7 +59,7 @@ const LoadingContainer = styled.div<{ isShow: boolean }>`
   backdrop-filter: blur(8px);
 
   // 애니메이션
-  transition: all ${delay}ms ease-out;
+  transition: all ${fadeoutTimeMs}ms ease-out;
   opacity: ${({ isShow }) => (isShow ? 1 : 0)};
 `;
 

--- a/src/contexts/AuthProvider/index.tsx
+++ b/src/contexts/AuthProvider/index.tsx
@@ -32,7 +32,11 @@ const AuthProvider = ({ children }: Props) => {
   }, [router]);
 
   useEffect(() => {
-    if (token) getCurrentUser();
+    if (token) {
+      getCurrentUser();
+    } else {
+      dispatch({ type: "LOADING_OFF" });
+    }
   }, []);
 
   return (

--- a/src/contexts/AuthProvider/index.tsx
+++ b/src/contexts/AuthProvider/index.tsx
@@ -2,6 +2,7 @@ import { useLocalToken } from "@hooks/domain";
 import { useRouter } from "next/router";
 import { useReducer, ReactNode, useEffect, useCallback } from "react";
 import userAPI from "service/userApi";
+import AuthLoading from "./AuthLoading";
 import { Context } from "./context";
 import { initialData, reducer } from "./reducer";
 
@@ -41,7 +42,7 @@ const AuthProvider = ({ children }: Props) => {
         getCurrentUser,
       }}
     >
-      {authProps.isLoading && <AuthLoading />}
+      <AuthLoading isShow={authProps.isLoading} />
       {children}
     </Context.Provider>
   );
@@ -50,7 +51,3 @@ const AuthProvider = ({ children }: Props) => {
 export default AuthProvider;
 
 export { default as useAuthContext } from "./hook";
-
-const AuthLoading = () => {
-  return <div>Loading</div>;
-};

--- a/src/contexts/AuthProvider/index.tsx
+++ b/src/contexts/AuthProvider/index.tsx
@@ -1,8 +1,8 @@
 import { useLocalToken } from "@hooks/domain";
 import { useRouter } from "next/router";
 import { useReducer, ReactNode, useEffect, useCallback } from "react";
-import userAPI from "service/userApi";
-import AuthLoading from "./AuthLoading";
+import userAPI from "@service/userApi";
+import { AuthLoading } from "@components/domain";
 import { Context } from "./context";
 import { initialData, reducer } from "./reducer";
 
@@ -23,13 +23,12 @@ const AuthProvider = ({ children }: Props) => {
       dispatch({ type: "GET_CURRENT_USER", payload: data });
       console.log(data);
     } catch (error) {
-      setToken("");
-      console.error(error);
+      localStorage.clear();
       router.replace("/login");
     } finally {
       dispatch({ type: "LOADING_OFF" });
     }
-  }, [router]);
+  }, [router, setToken]);
 
   useEffect(() => {
     if (token) {
@@ -46,12 +45,10 @@ const AuthProvider = ({ children }: Props) => {
         getCurrentUser,
       }}
     >
-      <AuthLoading isShow={authProps.isLoading} />
+      <AuthLoading />
       {children}
     </Context.Provider>
   );
 };
 
 export default AuthProvider;
-
-export { default as useAuthContext } from "./hook";

--- a/src/contexts/AuthProvider/reducer.ts
+++ b/src/contexts/AuthProvider/reducer.ts
@@ -38,7 +38,7 @@ export const initialData = {
     following: [],
     notifications: [],
   },
-  isLoading: false,
+  isLoading: true,
 };
 
 export const reducer: Reducer<DataProps, ReducerAction> = (

--- a/src/contexts/NavigationProvider/index.tsx
+++ b/src/contexts/NavigationProvider/index.tsx
@@ -65,5 +65,3 @@ const NavigationProvider = ({ children }: Props) => {
 };
 
 export default NavigationProvider;
-
-export { default as useNavigationContext } from "./hook";

--- a/src/contexts/hooks.ts
+++ b/src/contexts/hooks.ts
@@ -1,0 +1,2 @@
+export { default as useAuthContext } from "@contexts/AuthProvider/hook";
+export { default as useNavigationContext } from "@contexts/NavigationProvider/hook";

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -29,6 +29,12 @@ class MyDocument extends Document {
             defer
             src="https://developers.kakao.com/sdk/js/kakao.min.js"
           ></script>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Righteous&display=swap"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,11 +1,11 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import { KakaoLogin } from "@components/domain";
-import { useNavigationContext } from "@contexts/NavigationProvider";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import UtilRoute from "UtilRoute";
 import { useEffect } from "react";
+import { useNavigationContext } from "@contexts/hooks";
 
 const Login: NextPage = UtilRoute("prevented", () => {
   const { useMountPage, setCustomButtonEvent, clearNavigationEvent } =

--- a/src/pages/login/redirect/index.tsx
+++ b/src/pages/login/redirect/index.tsx
@@ -3,8 +3,8 @@ import { Header, Spinner } from "@components/base";
 import styled from "@emotion/styled";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useAuthContext } from "@contexts/AuthProvider";
 import { useLocalToken } from "@hooks/domain";
+import { useAuthContext } from "@contexts/hooks";
 
 const RedirectPage = () => {
   const [isNeedReLogin, setIsNeedReLogin] = useState(false);
@@ -26,7 +26,7 @@ const RedirectPage = () => {
 
   useEffect(() => {
     if (token) getCurrentUserData();
-  }, [token, getCurrentUserData]);
+  }, [token]);
 
   const NeedReLoginMarkUp = () => {
     return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@hooks/*": ["hooks/*"],
       "@stories/*": ["stories/*"],
       "@styles/*": ["styles/*"],
-      "@types/*": ["types/*"]
+      "@types/*": ["types/*"],
+      "@service/*": ["service/*"]
     },
     "types": ["kakao.maps.d.ts"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,6 +698,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-lottie@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@types/react-lottie/-/react-lottie-1.2.6.tgz#4f351dfdf5f93a46a3a9714fbb319f1e0f030eaf"
+  integrity sha512-fvGJHD7SeUdVESHo7f7erRnXkTWaa/6Mo5TB+R0/ieSftKoFspA4sMlF2qMH6BljXI7ehFJbBtrD5bzDxPCkGg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@17.0.37":
   version "17.0.37"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz"
@@ -1092,6 +1099,14 @@ babel-plugin-macros@^2.6.1:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1587,6 +1602,11 @@ core-js-pure@^3.19.0:
   version "3.19.1"
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.1.tgz"
   integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
+
+core-js@^2.4.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.1.3:
   version "3.19.2"
@@ -3410,6 +3430,11 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lottie-web@^5.1.3:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.8.1.tgz#807e0af0ad22b59bf867d964eb684cb3368da0ef"
+  integrity sha512-9gIizWADlaHC2GCt+D+yNpk5l2clZQFqnVWWIVdY0LnxC/uLa39dYltAe3fcmC/hrZ2IUQ8dLlY0O934Npjs7Q==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
@@ -4266,6 +4291,14 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lottie@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-lottie/-/react-lottie-1.2.3.tgz#8544b96939e088658072eea5e12d912cdaa3acc1"
+  integrity sha512-qLCERxUr8M+4mm1LU0Ruxw5Y5Fn/OmYkGfnA+JDM/dZb3oKwVAJCjwnjkj9TMHtzR2U6sMEUD3ZZ1RaHagM7kA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    lottie-web "^5.1.3"
+
 react-merge-refs@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
@@ -4375,6 +4408,11 @@ regenerator-runtime@0.13.4:
   version "0.13.4"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz"
   integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
200ms 로딩 페이드아웃 로딩

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
Lottie가 CPU를 많이 잡아 먹기 때문에 로딩의 fadeout 시간 만큼 뒤에 opacity가 0이 되면 Fragment로 교체하여 없앤다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture (3)](https://user-images.githubusercontent.com/61593290/145863388-3cba69f7-1c50-4434-be3e-a55779ae06cc.gif)


