### PR TITLE
✨ feat: IconButton, IconToggle 컴포넌트

### DIFF
--- a/src/components/base/Icon/index.tsx
+++ b/src/components/base/Icon/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   strokeWidth?: number;
   rotate?: number;
   color?: string;
+  fill?: boolean;
   [prop: string]: any;
 }
 
@@ -16,6 +17,7 @@ const Icon = ({
   strokeWidth = 2,
   rotate = 0,
   color = "#222",
+  fill = false,
   ...props
 }: Props) => {
   const shapeStyle = {
@@ -25,10 +27,11 @@ const Icon = ({
   };
 
   const iconStyle = {
-    "stroke-width": strokeWidth,
+    strokeWidth,
     stroke: color,
     width: size,
     height: size,
+    fill: fill ? color : "transparent",
   };
   const icon = Icons.icons[name];
   const svg = icon ? icon.toSvg(iconStyle) : "";
@@ -47,7 +50,7 @@ const IconWrapper = styled.i`
   display: inline-block;
 `;
 
-type FeatherIconNameType =
+export type FeatherIconNameType =
   | "arrow-down-left"
   | "arrow-down-right"
   | "arrow-down"

--- a/src/components/base/IconButton/index.tsx
+++ b/src/components/base/IconButton/index.tsx
@@ -26,4 +26,5 @@ const StyledIconButton = styled.button`
   border: 2px solid ${({ theme }) => theme.colors.gray100};
   border-radius: ${({ theme }) => theme.borderRadiuses.lg};
   padding: ${({ theme }) => theme.iconButtonPadding};
+  cursor: pointer;
 `;

--- a/src/components/base/IconButton/index.tsx
+++ b/src/components/base/IconButton/index.tsx
@@ -1,0 +1,29 @@
+import styled from "@emotion/styled";
+import type { MouseEvent } from "react";
+import Icon, { FeatherIconNameType } from "../Icon";
+
+interface Props {
+  name: FeatherIconNameType;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+const IconButton = ({ name, onClick }: Props) => {
+  return (
+    <StyledIconButton onClick={onClick}>
+      <Icon name={name} />
+    </StyledIconButton>
+  );
+};
+
+export default IconButton;
+
+const StyledIconButton = styled.button`
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 2px solid ${({ theme }) => theme.colors.gray100};
+  border-radius: ${({ theme }) => theme.borderRadiuses.lg};
+  padding: ${({ theme }) => theme.iconButtonPadding};
+`;

--- a/src/components/base/IconToggle/index.tsx
+++ b/src/components/base/IconToggle/index.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import React, { ChangeEvent } from "react";
+import Icon, { FeatherIconNameType } from "../Icon";
+
+interface Props {
+  name: FeatherIconNameType;
+  checked: boolean;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const IconToggle: React.FC<Props> = ({ name, checked, onChange }) => {
+  return (
+    <StyledIconToggleLabel>
+      <Icon name="star" fill={checked} />
+      <input type="checkbox" checked={checked} onChange={onChange} />
+    </StyledIconToggleLabel>
+  );
+};
+
+export default IconToggle;
+
+const StyledIconToggleLabel = styled.label`
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 2px solid ${({ theme }) => theme.colors.gray100};
+  border-radius: ${({ theme }) => theme.borderRadiuses.lg};
+  padding: ${({ theme }) => theme.iconButtonPadding};
+  input {
+    display: none;
+  }
+`;

--- a/src/components/base/IconToggle/index.tsx
+++ b/src/components/base/IconToggle/index.tsx
@@ -28,6 +28,7 @@ const StyledIconToggleLabel = styled.label`
   border: 2px solid ${({ theme }) => theme.colors.gray100};
   border-radius: ${({ theme }) => theme.borderRadiuses.lg};
   padding: ${({ theme }) => theme.iconButtonPadding};
+  cursor: pointer;
   input {
     display: none;
   }

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -19,3 +19,5 @@ export { default as Upload } from "./Upload";
 export { default as ModalSheet } from "./ModalSheet";
 export { default as Button } from "./Button";
 export { default as Input } from "./Input";
+export { default as IconButton } from "./IconButton";
+export { default as IconToggle } from "./IconToggle";


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
- 아이콘 버튼과 아이콘 토글(=체크박스)를 구현했습니ㅏㄷ.

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
- IconToggle 에서 아이콘 내부를 채워야 하기 때문에 Icon 컴포넌트에 `fill` props를 추가하였습니다.
- IconButton을 래핑해서 즐겨찾기, 지도뷰이동, 채팅방 이동 버튼을 도메인 컴포넌트에 만들어주세요!
- 사용법은 pages/hanna 에서 확인할 수 있습니다.


## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![chrome-capture (3)](https://user-images.githubusercontent.com/68159627/146180000-46d37206-2b79-4047-83b0-26c96b892f59.gif)

