### PR TITLE
💄 style: Input 컴포넌트 스타일링

### DIFF
--- a/src/components/base/Input/index.tsx
+++ b/src/components/base/Input/index.tsx
@@ -1,4 +1,6 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useState, FocusEvent } from "react";
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import Text from "../Text";
 
 interface Props extends HTMLAttributes<HTMLInputElement> {
@@ -6,16 +8,97 @@ interface Props extends HTMLAttributes<HTMLInputElement> {
   type: string;
   name: string;
   block?: boolean;
+  isRequired?: boolean;
   [x: string]: any;
 }
 
-const Input = ({ label, block, ...props }: Props) => (
-  <div>
-    <label>
-      <Text block={block}>{label}</Text>
-      <input {...props}></input>
-    </label>
-  </div>
-);
+const Input = ({ label, block, isRequired, type, ...props }: Props) => {
+  const [isFocus, setFocus] = useState(false);
+
+  const handleToggle = () => {
+    setFocus(!isFocus);
+  };
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement, Element>) => {
+    e.target.select();
+    handleToggle();
+  };
+
+  return (
+    <div>
+      <label>
+        <StyledText block={block} strong>
+          {label}
+          {isRequired ? <RequiredTag>*</RequiredTag> : null}
+        </StyledText>
+        <Container
+          className={isFocus ? "focus" : ""}
+          style={type === "number" ? { display: "flex" } : {}}
+        >
+          <InputContent
+            {...props}
+            type={type}
+            onFocus={handleFocus}
+            onBlur={handleToggle}
+            style={type === "number" ? { textAlign: "right" } : {}}
+          />
+          {type === "number" ? <Text strong>개</Text> : null}
+        </Container>
+      </label>
+    </div>
+  );
+};
 
 export default Input;
+
+const Container = styled.div`
+  ${({ theme }) => css`
+    box-sizing: border-box;
+    width: 100%;
+    background-color: ${theme.colors.white};
+    padding: ${theme.buttonPaddings.lg};
+    border-radius: ${theme.borderRadiuses.lg};
+    border: 1px solid ${theme.colors.gray300};
+    margin-top: ${theme.gaps.xs};
+
+    &.focus {
+      border: 1px solid ${theme.colors.slam.orange.strong};
+    }
+  `}
+`;
+
+const InputContent = styled.input`
+  ${({ theme }) => css`
+    box-sizing: border-box;
+    width: 100%;
+    color: ${theme.colors.gray900};
+    font-weight: bold;
+    border: none;
+
+    &::placeholder {
+      color: ${theme.colors.gray300};
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &[type="number"]::-webkit-outer-spin-button,
+    &[type="number"]::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+    }
+  `}
+`;
+
+const StyledText = styled(Text)`
+  ${({ theme }) => css`
+    color: ${theme.colors.gray900};
+  `}
+`;
+
+const RequiredTag = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.slam.orange.strong};
+    vertical-align: text-top;
+  `}
+`;

--- a/src/pages/user/edit/index.tsx
+++ b/src/pages/user/edit/index.tsx
@@ -128,6 +128,8 @@ const UserEditPage: NextPage = () => {
               name="nickname"
               onChange={handleChange}
               value={values.nickname}
+              isRequired
+              placeholder="15자 이내의 닉네임을 입력해주세요"
               block
             />
             <p>{errors.nickname}</p>
@@ -139,6 +141,7 @@ const UserEditPage: NextPage = () => {
               name="description"
               onChange={handleChange}
               value={values.description}
+              placeholder="ex) 저는 주로 파워포워드로 뛰고, 당산 주변에서 게임해요. 언제든 연락주세요."
               block
             />
             <p>{errors.description}</p>


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
Input 컴포넌트 스타일 작업

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #75 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- 기본적으로 container div로 input이 감싸져 있는 형태입니다. input에 포커스 될 때 container div에도 border 색깔이 바뀌는 이벤트를 적용해뒀는데, border 색깔은 임의로 넣어놓은 거라서 편하게 바꿔주시면 될 것 같습니다.
- input type(text, number)에 따라 다른 형태로 렌더링될 수 있도록 구현했습니다.
- 사용자 편의를 위해 number input 포커스될 때 자동으로 블록 지정해주도록 구현했습니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![인풋포커스](https://user-images.githubusercontent.com/84858773/146243800-675c1254-3ef9-4a81-8147-4e385e1568f7.gif)
![image](https://user-images.githubusercontent.com/84858773/146243946-c20aab1f-e979-4fcb-a53f-d6825c9d1bdf.png)

