### PR TITLE
✨ feat: 관리자용 새 농구장 리스트 조회 페이지

### DIFF
--- a/src/components/domain/NewCourtItem/index.tsx
+++ b/src/components/domain/NewCourtItem/index.tsx
@@ -1,0 +1,63 @@
+import styled from "@emotion/styled";
+import Link from "next/link";
+import { MouseEvent } from "react";
+import type { NewCourt } from "./types";
+
+interface Props {
+  data: NewCourt;
+  state: "READY" | "DONE";
+  [x: string]: any;
+}
+
+const NewCourtItem = ({ data, state, style }: Props) => {
+  const handleDeny = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    // TODO: API 보내기
+  };
+
+  const handleAccept = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    // TODO: API 보내기
+  };
+
+  return (
+    <Link href={`/admin/newcourts/${data.newCourtId}`} passHref>
+      <Container style={style}>
+        <p>{data.name}</p>
+        {state === "READY" ? (
+          <div>
+            <button onClick={handleDeny}>거절</button>
+            <button onClick={handleAccept}>승인</button>
+          </div>
+        ) : data.status === "ACCEPT" ? (
+          <StatusBar className="accept">승인</StatusBar>
+        ) : (
+          <StatusBar className="deny">거절</StatusBar>
+        )}
+      </Container>
+    </Link>
+  );
+};
+
+export default NewCourtItem;
+
+const Container = styled.a`
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid black;
+`;
+
+const StatusBar = styled.span`
+  height: 100%;
+
+  &.accept {
+    background: lightgreen;
+  }
+
+  &.deny {
+    background: orange;
+  }
+`;

--- a/src/components/domain/NewCourtItem/types.ts
+++ b/src/components/domain/NewCourtItem/types.ts
@@ -1,0 +1,34 @@
+const textures = {
+  RUBBER: "고무",
+  URETHANE: "우레탄",
+  ASPHALT: "아스팔트",
+  SOIL: "흙",
+  CONCRETE: "콘크리트",
+  ETC: "기타",
+} as const;
+
+const status = {
+  ACCEPT: "승인",
+  DENY: "거절",
+  READY: "대기",
+} as const;
+
+type Texture = typeof textures;
+export type TextureValueUnion = Texture[keyof Texture];
+export type TextureKeyUnion = keyof Texture;
+
+type Status = typeof status;
+export type StatusValueUnion = Status[keyof Status];
+export type StatusKeyUnion = keyof Status;
+
+export interface NewCourt {
+  newCourtId: number;
+  name: string;
+  basketCount: number;
+  longitude: number;
+  latitude: number;
+  image: string | null;
+  texture: TextureKeyUnion | null;
+  status: StatusKeyUnion;
+  createdAt: string;
+}

--- a/src/components/domain/NotificationList/NotificationItem/index.tsx
+++ b/src/components/domain/NotificationList/NotificationItem/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Notification } from "@contexts/AuthProvider/types";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { Avatar, LinkStrong } from "@components/base";
+import { LinkStrong } from "@components/base";
 import { LinkAvatar } from "@components/domain";
 
 interface Props {

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -17,3 +17,7 @@ export { default as Participants } from "./ReservationItem/ReservationItemBottom
 export { default as FollowListItem } from "./FollowListItem";
 export { default as LoudSpeaker } from "./ReservationItem/Loudspeaker";
 export { default as ReservationItem } from "./ReservationItem";
+export { default as NewCourtItem } from "./NewCourtItem";
+export type { NewCourt } from "./NewCourtItem/types";
+// eslint-disable-next-line import/no-cycle
+export { default as NotificationList } from "./NotificationList";

--- a/src/contexts/NavigationProvider/actionTypes.ts
+++ b/src/contexts/NavigationProvider/actionTypes.ts
@@ -21,6 +21,7 @@ export const pageType = {
   CHATROOM: "CHATROOM",
   USER_CHATROOM: "USER_CHATROOM",
   COURT_CHATROOM: "COURT_CHATROOM",
+  ADMIN_NEWCOURTS: "ADMIN_NEWCOURTS",
 } as const;
 
 export const navigationType = {

--- a/src/contexts/NavigationProvider/reducer.ts
+++ b/src/contexts/NavigationProvider/reducer.ts
@@ -178,6 +178,20 @@ export const reducer: Reducer<DataProps, ReducerAction> = (
         title: "프로필 편집",
       };
     }
+    case pageType.ADMIN_NEWCOURTS: {
+      return {
+        ...prevState,
+        isTopNavigation: true,
+        isBottomNavigation: true,
+        currentPage: type,
+        isBack: true,
+        isNotifications: false,
+        isProfile: false,
+        isNext: false,
+        isMenu: true,
+        title: "새 농구장 리스트",
+      };
+    }
     case pageType.USER_MENU: {
       return {
         ...prevState,

--- a/src/pages/admin/newcourts.tsx
+++ b/src/pages/admin/newcourts.tsx
@@ -1,0 +1,12 @@
+import { useNavigationContext } from "@contexts/hooks";
+import { NextPage } from "next";
+import React from "react";
+
+const NewCourtsPage: NextPage = () => {
+  const { useMountPage } = useNavigationContext();
+  useMountPage((page) => page.ADMIN_NEWCOURTS);
+
+  return <div>관리자용 새 농구장 리스트 페이지</div>;
+};
+
+export default NewCourtsPage;

--- a/src/pages/admin/newcourts.tsx
+++ b/src/pages/admin/newcourts.tsx
@@ -1,12 +1,131 @@
 import { useNavigationContext } from "@contexts/hooks";
 import { NextPage } from "next";
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { Spacer } from "@components/base";
+import styled from "@emotion/styled";
+import { NewCourtItem, NewCourt } from "@components/domain";
 
 const NewCourtsPage: NextPage = () => {
   const { useMountPage } = useNavigationContext();
   useMountPage((page) => page.ADMIN_NEWCOURTS);
 
-  return <div>관리자용 새 농구장 리스트 페이지</div>;
+  // 더미 데이터
+  const initialData: NewCourt[] = [
+    {
+      newCourtId: 1,
+      name: "반포한강공원 체력단련장 농구장",
+      basketCount: 1,
+      longitude: 126.995269636407,
+      latitude: 37.5097694752014,
+      image: null,
+      texture: "RUBBER",
+      status: "READY",
+      createdAt: "2021-01-01T12:20:10",
+    },
+    {
+      newCourtId: 2,
+      name: "잠실한강공원 농구장",
+      basketCount: 1,
+      longitude: 127.082348760182,
+      latitude: 37.5177740347208,
+      image: null,
+      texture: "RUBBER",
+      status: "ACCEPT",
+      createdAt: "2021-01-01T12:20:10",
+    },
+    {
+      newCourtId: 3,
+      name: "잘못된 농구장",
+      basketCount: 1,
+      longitude: 127.077064497635,
+      latitude: 37.5270939663765,
+      image: null,
+      texture: "RUBBER",
+      status: "DENY",
+      createdAt: "2021-01-01T12:20:10",
+    },
+  ];
+
+  const [data, setData] = useState<NewCourt[]>(initialData);
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+
+  const filterData = (state: "READY" | "DONE") => {
+    if (state === "READY") {
+      setData(initialData.filter((court) => court.status === "READY"));
+    } else {
+      setData(initialData.filter((court) => court.status !== "READY"));
+    }
+  };
+
+  const menuTab = [
+    {
+      tabTitle: (index: number) => (
+        <li
+          key={index}
+          className={activeIndex === 0 ? "is-active" : ""}
+          onClick={() => {
+            filterData("READY");
+            tabClickHandler(0);
+          }}
+        >
+          처리 대기
+        </li>
+      ),
+      tabContent: (courtData: NewCourt) => (
+        <NewCourtItem
+          key={courtData.newCourtId}
+          data={courtData}
+          state="READY"
+        />
+      ),
+    },
+    {
+      tabTitle: (index: number) => (
+        <li
+          key={index}
+          className={activeIndex === 1 ? "is-active" : ""}
+          onClick={() => {
+            filterData("DONE");
+            tabClickHandler(1);
+          }}
+        >
+          처리 완료
+        </li>
+      ),
+      tabContent: (courtData: NewCourt) => (
+        <NewCourtItem
+          key={courtData.newCourtId}
+          data={courtData}
+          state="DONE"
+        />
+      ),
+    },
+  ];
+
+  const tabClickHandler = (index: number) => {
+    setActiveIndex(index);
+  };
+
+  useEffect(() => {
+    filterData("READY");
+  }, []);
+
+  return (
+    <div>
+      <TabStyle>
+        {menuTab.map((section, index) => section.tabTitle(index))}
+      </TabStyle>
+      <Spacer gap="base" type="vertical">
+        {data.map((court) => menuTab[activeIndex].tabContent(court))}
+      </Spacer>
+    </div>
+  );
 };
 
 export default NewCourtsPage;
+
+const TabStyle = styled.ul`
+  .is-active {
+    color: red;
+  }
+`;


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
관리자용 사용자가 추가한 새 농구장 리스트 조회 페이지의 기본적인 마크업을 구현했습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #49 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- `처리 대기` / `처리 완료` 상태별로 데이터를 조회할 수 있게 구현했습니다.
- 저번 스크럼 때 리스트 아이템을 클릭하면 상세 정보를 볼 수 있는 페이지로 이동할 수 있게끔 구현하겠다고 말씀드렸었는데요. 현재 newCourts를 조회하는 api가 전체 데이터를 배열에 담아 보내주는 것 하나 뿐인데 상세 정보를 조회하는 페이지를 구현하려면 newCourtId에 해당하는 각각의 상세 정보를 조회할 수 있는 api가 필요할까요? 아니면 전체 데이터를 조회한 결과에서 해당 상세 정보를 추출해서 route를 이동할 때 보내주는 방식으로 구현하면 되는 걸까요? 궁금해져서 일단 남겨놓습니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/84858773/146426547-5c857bfe-87be-4226-8357-0dc7f89c06c1.png)
![image](https://user-images.githubusercontent.com/84858773/146426579-9cd102ed-bc59-48e6-9091-b572eeb7bc0e.png)
