### PR TITLE
🚸 improve: 프로필 페이지 수정 및 스타일 작업

### DIFF
--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   size?: Size;
   type?: "button" | "submit";
   secondary?: boolean;
+  tertiary?: boolean;
   fullWidth?: boolean;
   block?: boolean;
   disabled?: boolean;
@@ -24,6 +25,7 @@ const Button: React.FC<Props> = ({
   block = false,
   disabled = false,
   secondary = false,
+  tertiary = false,
   type = "button",
   size = "md",
   style,
@@ -37,6 +39,7 @@ const Button: React.FC<Props> = ({
       type={type}
       fullWidth={fullWidth}
       secondary={secondary}
+      tertiary={tertiary}
       onClick={onClick}
       style={style}
       disabled={disabled}
@@ -75,6 +78,20 @@ const StyledButton = styled.button<Omit<Props, "children">>`
 
       &:hover {
         background-color: ${theme.colors.gray200};
+      }
+    `}
+
+    ${({ theme, tertiary }) =>
+    tertiary &&
+    css`
+      & {
+        background-color: ${theme.colors.gray200};
+        color: ${theme.colors.gray900};
+        border: 1px solid ${theme.colors.gray300};
+      }
+
+      &:hover {
+        background-color: ${theme.colors.gray400};
       }
     `}
   font-weight: bold;

--- a/src/components/base/Chip/index.tsx
+++ b/src/components/base/Chip/index.tsx
@@ -1,0 +1,73 @@
+import { ReactNode, HTMLAttributes } from "react";
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import Text from "../Text";
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+  size?: number | "xs" | "sm" | "base" | "md" | "lg" | "xl";
+  clickable?: boolean;
+  border?: boolean;
+  secondary?: boolean;
+}
+
+const Chip = ({
+  size = "xs",
+  children,
+  clickable = false,
+  border = false,
+  secondary = false,
+  ...props
+}: Props) => {
+  return (
+    <ChipItem
+      size={size}
+      color="white"
+      strong
+      {...props}
+      clickable={clickable}
+      border={border}
+      secondary={secondary}
+    >
+      {children}
+    </ChipItem>
+  );
+};
+
+export default Chip;
+
+const ChipItem = styled(Text)`
+  ${({ theme }) => css`
+    background-color: ${theme.colors.white};
+    color: ${theme.colors.gray700};
+
+    border-radius: ${theme.borderRadiuses.lg};
+    padding: ${theme.chipPadding};
+    display: inline-block;
+    margin-bottom: ${theme.gaps.xs};
+    cursor: default;
+  `}
+
+  ${({ theme, clickable }) =>
+    clickable &&
+    css`
+      cursor: pointer;
+
+      &:hover {
+        background-color: ${theme.colors.gray300};
+      }
+    `}
+
+  ${({ theme, secondary }) =>
+    secondary &&
+    css`
+      background-color: ${theme.colors.gray900};
+      color: ${theme.colors.white};
+    `}
+
+  ${({ theme, border }) =>
+    border &&
+    css`
+      border: 1px solid ${theme.colors.gray300};
+    `}
+`;

--- a/src/components/base/RadioInput/RadioItem.tsx
+++ b/src/components/base/RadioInput/RadioItem.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { Text } from "@components/base";
+import { Chip } from "@components/base";
 
 interface RadioItemProps {
   value: string;
@@ -10,21 +10,19 @@ interface RadioItemProps {
 
 const RadioItem: React.FC<RadioItemProps> = ({ value, text, checked }) => {
   return (
-    <Label>
+    <StyledLabel>
       <StyledRadio
         type="radio"
         value={value}
         checked={checked}
         onChange={() => {}}
       />
-      <Text size="xs" strong>
-        {text}
-      </Text>
-    </Label>
+      <Chip clickable>{text}</Chip>
+    </StyledLabel>
   );
 };
 
-const Label = styled.label`
+const StyledLabel = styled.label`
   margin-right: ${({ theme }) => theme.gaps.xs};
 `;
 
@@ -32,20 +30,6 @@ const StyledRadio = styled.input`
   display: none;
 
   ${({ theme }) => css`
-    & + span {
-      background-color: ${theme.colors.white};
-      color: ${theme.colors.gray700};
-      border-radius: ${theme.borderRadiuses.lg};
-      padding: ${theme.chipPadding};
-      display: inline-block;
-      margin-bottom: ${theme.gaps.xs};
-      cursor: pointer;
-
-      &:hover {
-        background-color: ${theme.colors.gray300};
-      }
-    }
-
     &:checked + span {
       background-color: ${theme.colors.gray900};
       color: ${theme.colors.white};

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -22,6 +22,7 @@ export { default as IconButton } from "./IconButton";
 export { default as IconToggle } from "./IconToggle";
 export { default as LinkStrong } from "./LinkStrong";
 export { default as Label } from "./Label";
+export { default as Chip } from "./Chip";
 /* eslint-disable import/no-cycle */
 export { default as Input } from "./Input";
 export { default as Radio } from "./RadioInput";

--- a/src/components/domain/ProfileFavoritesListItem/index.tsx
+++ b/src/components/domain/ProfileFavoritesListItem/index.tsx
@@ -1,0 +1,47 @@
+import React, { HTMLAttributes } from "react";
+import styled from "@emotion/styled";
+import type { ReactNode } from "react";
+import { Icon, Button, Spacer, Text } from "@components/base";
+import Link from "next/link";
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  className?: string;
+  courtId: number;
+}
+
+const ProfileFavoritesListItem: React.FC<Props> = ({
+  children,
+  className,
+  courtId,
+}) => {
+  return (
+    <ListItem className={className}>
+      <Spacer
+        gap={10}
+        style={{
+          alignItems: "center",
+        }}
+      >
+        <Icon name="map-pin" color="#FE6D04" />
+        <Text size="base">{children}</Text>
+      </Spacer>
+      <div>
+        <Button secondary>
+          <Link href={`/courts?courtId=${courtId}`} passHref>
+            <a>지도 보기</a>
+          </Link>
+        </Button>
+      </div>
+    </ListItem>
+  );
+};
+
+const ListItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${({ theme }) => theme.gaps.xs} 0;
+`;
+
+export default ProfileFavoritesListItem;

--- a/src/components/domain/UserInfoPicker/types.tsx
+++ b/src/components/domain/UserInfoPicker/types.tsx
@@ -15,8 +15,8 @@ const proficiencies = {
 
 type Position = typeof positions;
 export type PositionValueUnion = Position[keyof Position];
-export type PositionKeyUnion = keyof Position;
+export type PositionKeyUnion = keyof Position | null;
 
 type Proficiency = typeof proficiencies;
 export type ProficiencyValueUnion = Proficiency[keyof Proficiency];
-export type ProficiencyKeyUnion = keyof Proficiency;
+export type ProficiencyKeyUnion = keyof Proficiency | null;

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -25,6 +25,6 @@ export type {
   ProficiencyKeyUnion,
 } from "./UserInfoPicker/types";
 export { default as ValidationNoticeBar } from "./ValidationNoticeBar";
-
+export { default as ProfileFavoritesListItem } from "./ProfileFavoritesListItem";
 // eslint-disable-next-line import/no-cycle
 export { default as NotificationList } from "./NotificationList";

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -7,11 +7,13 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { Avatar, Button, Label, Spacer, Chip } from "@components/base";
 import { useNavigationContext, useAuthContext } from "@contexts/hooks";
-import { ProfileFavoritesListItem } from "@components/domain";
+import {
+  ProfileFavoritesListItem,
+  ProficiencyKeyUnion,
+  PositionKeyUnion,
+} from "@components/domain";
 
 type IUserType = "other" | "me";
-type IProficiency = "BEGINNER" | "INTERMEDIATE" | "MASTER" | null;
-type IPositions = "PF" | "SF" | "SG" | "PG" | "C" | "TBD";
 
 const User: NextPage = () => {
   const { useMountPage, setNavigationTitle } = useNavigationContext();
@@ -92,7 +94,7 @@ const User: NextPage = () => {
   const positions = userInfo.positions ?? ["TBD"];
   const favoriteCourts = userInfo.favoriteCourts ?? [];
 
-  const proficiencyToKorean = (proficiency: IProficiency) => {
+  const proficiencyToKorean = (proficiency: ProficiencyKeyUnion) => {
     switch (proficiency) {
       case "BEGINNER":
         return "뉴비";
@@ -105,7 +107,7 @@ const User: NextPage = () => {
     }
   };
 
-  const positionsToKorean = (positions: IPositions) => {
+  const positionsToKorean = (positions: PositionKeyUnion) => {
     switch (positions) {
       case "PF":
         return "파워포워드";
@@ -190,7 +192,7 @@ const User: NextPage = () => {
           <Spacer gap="xs">
             {positions.map((position, index) => (
               <Chip key={index} secondary>
-                {positionsToKorean(position as IPositions)}
+                {positionsToKorean(position as PositionKeyUnion)}
               </Chip>
             ))}
           </Spacer>
@@ -198,7 +200,7 @@ const User: NextPage = () => {
         <div>
           <Label>숙련도</Label>
           <Chip secondary>
-            {proficiencyToKorean(proficiency as IProficiency)}
+            {proficiencyToKorean(proficiency as ProficiencyKeyUnion)}
           </Chip>
         </div>
         <div>

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -7,6 +7,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { Avatar, Button, Label, Spacer, Chip } from "@components/base";
 import { useNavigationContext, useAuthContext } from "@contexts/hooks";
+import { ProfileFavoritesListItem } from "@components/domain";
 
 type IUserType = "other" | "me";
 type IProficiency = "BEGINNER" | "INTERMEDIATE" | "MASTER";
@@ -194,18 +195,16 @@ const User: NextPage = () => {
             {proficiencyToKorean(proficiency as IProficiency)}
           </Chip>
         </div>
-        {userType === "other" ? (
-          <div>
-            <Label>내가 즐겨찾는 농구장</Label>
-            {favoriteCourts.map(({ courtId, courtName }, index) => (
-              <Chip key={index} secondary>
-                <Link href={`/courts?courtId=${courtId}`} passHref>
-                  <a>{courtName}</a>
-                </Link>
-              </Chip>
-            ))}
-          </div>
-        ) : null}
+        <div>
+          <Label>
+            {userType === "me" ? "내가" : `${nickname}님이`} 즐겨찾는 농구장
+          </Label>
+          {favoriteCourts.map(({ courtId, courtName }) => (
+            <ProfileFavoritesListItem key={courtId} courtId={courtId}>
+              {courtName}
+            </ProfileFavoritesListItem>
+          ))}
+        </div>
       </AdditionalInfoContainer>
     </div>
   );

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -153,7 +153,12 @@ const User: NextPage = () => {
             </div>
             <div>
               <dt>평가 점수</dt>
-              <dd>?</dd>
+              <dd
+                onClick={() => alert("개발 예정")}
+                style={{ cursor: "pointer" }}
+              >
+                ?
+              </dd>
             </div>
           </StatBar>
         </MainInfoArea>

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -4,12 +4,13 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import styled from "@emotion/styled";
-import { Avatar } from "@components/base";
-import { useAuthContext, useNavigationContext } from "@contexts/hooks";
+import { css } from "@emotion/react";
+import { Avatar, Button, Label, Spacer, Chip } from "@components/base";
+import { useNavigationContext, useAuthContext } from "@contexts/hooks";
 
 type IUserType = "other" | "me";
-type ISkill = "BEGINNER" | "INTERMEDIATE" | "MASTER";
-type IPosition = "PF" | "SF" | "SG" | "PG" | "C" | "UNDEFINED";
+type IProficiency = "BEGINNER" | "INTERMEDIATE" | "MASTER";
+type IPositions = "PF" | "SF" | "SG" | "PG" | "C" | "UNDEFINED";
 
 const User: NextPage = () => {
   const { useMountPage, setNavigationTitle } = useNavigationContext();
@@ -26,27 +27,29 @@ const User: NextPage = () => {
   const [isFollowing, setIsFollowing] = useState<boolean>(false);
 
   // 더미 데이터
-  const myUserId = 1234; // TODO: AuthContext에서 userId 가져오기
+  const myUserId = 1; // TODO: AuthContext에서 userId 가져오기
   const userInfo = {
-    nickname: "slam",
+    userId: 1,
+    nickname: "슬램",
     followerCount: 500,
     followingCount: 300,
     profileImage:
       "https://user-images.githubusercontent.com/84858773/145361283-80b23317-3038-42e6-a784-f82015535514.png",
-    description: "내 이름은 슬램, 농구인이죠",
-    skill: "BEGINNER",
-    position: "PF",
+    description:
+      "저는 농구할 때 파워포워드를 주로 하고, 당산 주변에서 주로 게임해요. 언제든지 연락 주세요.",
+    proficiency: "BEGINNER",
+    positions: ["PF", "SG"],
     favoriteCourts: [
       {
-        courtId: 123,
+        courtId: 1,
         courtName: "용왕산 공원 농구장",
       },
       {
-        courtId: 124,
+        courtId: 2,
         courtName: "설악산 공원 농구장",
       },
       {
-        courtId: 125,
+        courtId: 3,
         courtName: "북한산 공원 농구장",
       },
     ],
@@ -64,10 +67,10 @@ const User: NextPage = () => {
     // TODO: path의 userId와 AuthContext의 userId 비교하기
     if (userId === myUserId) {
       setUserType("me");
-      setNavigationTitle("내 프로필");
+      setNavigationTitle(`${nickname}`);
     } else {
       // TODO: 유저 정보 조회 API 통신으로 해당 유저 정보 받아오기
-      setNavigationTitle(`${nickname}님의 프로필`);
+      setNavigationTitle(`${nickname}`);
     }
 
     // TODO: 내가 팔로우한 유저 목록 받아오기
@@ -82,13 +85,13 @@ const User: NextPage = () => {
     followingCount,
     profileImage,
     description,
-    skill,
-    position,
+    proficiency,
+    positions,
     favoriteCourts,
   } = userInfo;
 
-  const skillToKorean = (skill: ISkill) => {
-    switch (skill) {
+  const proficiencyToKorean = (proficiency: IProficiency) => {
+    switch (proficiency) {
       case "BEGINNER":
         return "뉴비";
       case "INTERMEDIATE":
@@ -100,18 +103,18 @@ const User: NextPage = () => {
     }
   };
 
-  const positionToKorean = (position: IPosition) => {
-    switch (position) {
+  const positionsToKorean = (positions: IPositions) => {
+    switch (positions) {
       case "PF":
-        return "파워 포워드(PF)";
+        return "파워포워드";
       case "SF":
-        return "스몰 포워드(SF)";
+        return "스몰포워드";
       case "SG":
-        return "슈팅 가드(SG)";
+        return "슈팅가드";
       case "PG":
-        return "포인트 가드(PG)";
+        return "포인트가드";
       case "C":
-        return "센터(C)";
+        return "센터";
       default:
         return "미정";
     }
@@ -134,78 +137,134 @@ const User: NextPage = () => {
         <meta name="description" content="혼자서도 농구를 더 빠르게" />
       </Head>
 
-      <Center>
-        <Avatar src={profileImage} shape="circle" />
-        <p>{nickname}</p>
-        <p>{description}</p>
-
-        <Table>
-          <thead>
-            <tr>
-              <th>팔로워</th>
-              <th>팔로잉</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>{followerCount}</td>
-              <td>{followingCount}</td>
-            </tr>
-          </tbody>
-        </Table>
+      <MainInfoContainer>
+        <MainInfoArea>
+          <Avatar src={profileImage} shape="circle" />
+          <StatBar>
+            <div>
+              <dt>팔로잉</dt>
+              <dd>{followingCount}</dd>
+            </div>
+            <div>
+              <dt>팔로워</dt>
+              <dd>{followerCount}</dd>
+            </div>
+            <div>
+              <dt>평가 점수</dt>
+              <dd>?</dd>
+            </div>
+          </StatBar>
+        </MainInfoArea>
+        <Description>{description}</Description>
         {userType === "other" ? (
-          <div>
-            <button onClick={handleFollow}>
-              {isFollowing ? `언팔로우` : `팔로우`}
-            </button>
-            <button>
+          <ButtonContainer>
+            <Button fullWidth secondary>
               <Link href={`/chat/${userId}`} passHref>
                 <a>메시지</a>
               </Link>
-            </button>
-          </div>
+            </Button>
+            <Button fullWidth tertiary={isFollowing} onClick={handleFollow}>
+              {isFollowing ? `팔로잉` : `팔로우`}
+            </Button>
+          </ButtonContainer>
         ) : (
           <div>
-            <button>
-              <Link href={`/user/${userId}/edit`} passHref>
+            <Button fullWidth secondary>
+              <Link href={`/user/edit`} passHref>
                 <a>프로필 편집</a>
               </Link>
-            </button>
+            </Button>
           </div>
         )}
-      </Center>
-      <p>숙련도</p>
-      <Tag>{skillToKorean(skill as ISkill)}</Tag>
-      <p>포지션</p>
-      <Tag>{positionToKorean(position as IPosition)}</Tag>
-      {userType === "other" ? (
+      </MainInfoContainer>
+      <AdditionalInfoContainer gap="base" type="vertical">
         <div>
-          <p>즐겨찾기 농구장</p>
-          {favoriteCourts.map(({ courtId, courtName }, index) => (
-            <Tag key={index}>
-              <Link href={`/courts?courtId=${courtId}`} passHref>
-                <a>{courtName}</a>
-              </Link>
-            </Tag>
-          ))}
+          <Label>포지션</Label>
+          <Spacer gap="xs">
+            {positions.map((position, index) => (
+              <Chip key={index} secondary>
+                {positionsToKorean(position as IPositions)}
+              </Chip>
+            ))}
+          </Spacer>
         </div>
-      ) : null}
+        <div>
+          <Label>숙련도</Label>
+          <Chip secondary>
+            {proficiencyToKorean(proficiency as IProficiency)}
+          </Chip>
+        </div>
+        {userType === "other" ? (
+          <div>
+            <Label>내가 즐겨찾는 농구장</Label>
+            {favoriteCourts.map(({ courtId, courtName }, index) => (
+              <Chip key={index} secondary>
+                <Link href={`/courts?courtId=${courtId}`} passHref>
+                  <a>{courtName}</a>
+                </Link>
+              </Chip>
+            ))}
+          </div>
+        ) : null}
+      </AdditionalInfoContainer>
     </div>
   );
 };
 
 export default User;
 
-const Tag = styled.span`
-  background-color: lightgray;
-  margin-right: 10px;
+const MainInfoContainer = styled.div`
+  ${({ theme }) => css`
+    padding: ${theme.gaps.lg} ${theme.gaps.base} ${theme.gaps.md};
+    background: ${theme.colors.white};
+  `}
 `;
 
-const Center = styled.div`
-  text-align: center;
+const AdditionalInfoContainer = styled(Spacer)`
+  ${({ theme }) => css`
+    padding: ${theme.gaps.md} ${theme.gaps.base};
+  `}
 `;
 
-const Table = styled.table`
-  text-align: center;
-  margin: 0 auto;
+const FlexContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const MainInfoArea = styled(FlexContainer)`
+  ${({ theme }) => css`
+    padding: 0 ${theme.gaps.xs};
+  `}
+`;
+
+const ButtonContainer = styled(FlexContainer)`
+  ${({ theme }) => css`
+    gap: 0 ${theme.gaps.xs};
+  `}
+`;
+
+const StatBar = styled.dl`
+  ${({ theme }) => css`
+    display: flex;
+    text-align: center;
+    margin: 0;
+    flex-grow: 1;
+    margin-left: ${theme.gaps.lg};
+    justify-content: space-evenly;
+
+    dd {
+      box-sizing: border-box;
+      margin: 0;
+      font-weight: bold;
+      padding: ${theme.gaps.xs} 0;
+    }
+  `}
+`;
+
+const Description = styled.div`
+  ${({ theme }) => css`
+    margin: ${theme.gaps.md} 0;
+    line-height: 1.4;
+  `}
 `;

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -10,8 +10,8 @@ import { useNavigationContext, useAuthContext } from "@contexts/hooks";
 import { ProfileFavoritesListItem } from "@components/domain";
 
 type IUserType = "other" | "me";
-type IProficiency = "BEGINNER" | "INTERMEDIATE" | "MASTER";
-type IPositions = "PF" | "SF" | "SG" | "PG" | "C" | "UNDEFINED";
+type IProficiency = "BEGINNER" | "INTERMEDIATE" | "MASTER" | null;
+type IPositions = "PF" | "SF" | "SG" | "PG" | "C" | "TBD";
 
 const User: NextPage = () => {
   const { useMountPage, setNavigationTitle } = useNavigationContext();
@@ -38,8 +38,8 @@ const User: NextPage = () => {
       "https://user-images.githubusercontent.com/84858773/145361283-80b23317-3038-42e6-a784-f82015535514.png",
     description:
       "저는 농구할 때 파워포워드를 주로 하고, 당산 주변에서 주로 게임해요. 언제든지 연락 주세요.",
-    proficiency: "BEGINNER",
-    positions: ["PF", "SG"],
+    proficiency: null,
+    positions: null,
     favoriteCourts: [
       {
         courtId: 1,
@@ -87,9 +87,10 @@ const User: NextPage = () => {
     profileImage,
     description,
     proficiency,
-    positions,
-    favoriteCourts,
   } = userInfo;
+
+  const positions = userInfo.positions ?? ["TBD"];
+  const favoriteCourts = userInfo.favoriteCourts ?? [];
 
   const proficiencyToKorean = (proficiency: IProficiency) => {
     switch (proficiency) {
@@ -199,11 +200,15 @@ const User: NextPage = () => {
           <Label>
             {userType === "me" ? "내가" : `${nickname}님이`} 즐겨찾는 농구장
           </Label>
-          {favoriteCourts.map(({ courtId, courtName }) => (
-            <ProfileFavoritesListItem key={courtId} courtId={courtId}>
-              {courtName}
-            </ProfileFavoritesListItem>
-          ))}
+          {favoriteCourts.length < 1 ? (
+            <Chip secondary>정보 없음</Chip>
+          ) : (
+            favoriteCourts.map(({ courtId, courtName }) => (
+              <ProfileFavoritesListItem key={courtId} courtId={courtId}>
+                {courtName}
+              </ProfileFavoritesListItem>
+            ))
+          )}
         </div>
       </AdditionalInfoContainer>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,4 +5,10 @@
 
 body {
   font-family: "Spoqa Han Sans Neo", "sans-serif";
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
프로필 페이지 수정 및 스타일 작업

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #33 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- 포지션, 숙련도, 즐겨찾는 농구장 정보가 null로 들어올 때 아래의 스크린 샷처럼 스타일 작업했는데 농구장 부분이 좀 이상한 것 같아요.. 근데 그냥 텍스트로 하는 것도 이상하더라고요. 여러분의 의견이 궁금하네요.
![image](https://user-images.githubusercontent.com/84858773/146539499-838fa13f-931f-4ab5-b6e2-0a74f3f91b93.png)
![image](https://user-images.githubusercontent.com/84858773/146539769-c1d96cef-4170-44a9-b0b5-a6a64cbf1970.png)
- `proficiencyToKorean` 함수를 만들어 "BEGINNER", "INTERMEDIATE"와 같은 value 값을 한글 키워드로 바꿔주도록 구현했는데 이 텍스트를 여러 군데에서 반복해서 적고 있어서 이 방법이 적절한지 고민이 되더라구요. 혹시 좋은 아이디어를 있다면 알려주시면 리팩토링 할 때 반영하겠습니다!


## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->

* 내 프로필
![image](https://user-images.githubusercontent.com/84858773/146539225-ce7e0355-f95e-43d9-b31f-b37738aaa1fb.png)

* 팔로우하지 않은 다른 유저 프로필
![image](https://user-images.githubusercontent.com/84858773/146539344-00b79c32-ad60-480c-b175-452e8b5aa594.png)

* 팔로우한 다른 유저 프로필
![image](https://user-images.githubusercontent.com/84858773/146539410-4f185bfb-5aea-49e6-9f28-e6d69766c656.png)
