### PR TITLE
🐛 fix: UtilRoute 기본 privateRedirectPath 변경 #138

### DIFF
--- a/src/UtilRoute/index.tsx
+++ b/src/UtilRoute/index.tsx
@@ -30,6 +30,10 @@ const UtilRouteHOCWrapper = ({
   option: RouteOptionUnion;
   children: ReactNode;
 }) => {
+  // TODO: Version2에서 private / prevented RedirectPath Props로 받아오도록 변경하기
+  const privateRedirectPath = "/courts";
+  const preventedRedirectPath = "/";
+
   const [localToken] = useLocalToken();
   const router = useRouter();
 
@@ -42,12 +46,12 @@ const UtilRouteHOCWrapper = ({
           if (localToken) {
             router.replace({ pathname: `${pathname}`, query: router.query });
           } else {
-            router.replace("/login");
+            router.replace(privateRedirectPath);
           }
           break;
         case routeOption.prevented:
           if (localToken) {
-            router.replace("/");
+            router.replace(preventedRedirectPath);
           } else {
             router.replace({ pathname: `${pathname}`, query: router.query });
           }


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
Private 라우트가드의 리다이렉팅이 탐색페이지를 향하도록 변경했습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
 #138 

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
- 변경점은 명확하기 때문에 셀프로 머지하겠습니다.
- TODO: 버전 2에서 UtilRoute의 Props로 리다이렉팅을 수정할 수 있도록 변경하겠습니다.
