### PR TITLE
🐛 fix: 지나간 시간에 대한 예약 및 지도뷰 조회 비활성화

### DIFF
--- a/src/components/base/RadioInput/RadioItem.tsx
+++ b/src/components/base/RadioInput/RadioItem.tsx
@@ -6,9 +6,15 @@ interface RadioItemProps {
   value: string;
   text: string;
   checked: boolean;
+  disabled?: boolean;
 }
 
-const RadioItem: React.FC<RadioItemProps> = ({ value, text, checked }) => {
+const RadioItem: React.FC<RadioItemProps> = ({
+  value,
+  text,
+  checked,
+  disabled,
+}) => {
   return (
     <StyledLabel>
       <StyledRadio
@@ -16,6 +22,7 @@ const RadioItem: React.FC<RadioItemProps> = ({ value, text, checked }) => {
         value={value}
         checked={checked}
         onChange={() => {}}
+        disabled={disabled}
       />
       <Chip clickable>{text}</Chip>
     </StyledLabel>
@@ -44,6 +51,10 @@ const StyledRadio = styled.input`
       &:hover {
         background-color: ${theme.colors.gray700};
       }
+    }
+
+    &:disabled {
+      background-color: aqua;
     }
   `}
 `;

--- a/src/components/base/RadioInput/RadioItem.tsx
+++ b/src/components/base/RadioInput/RadioItem.tsx
@@ -40,23 +40,26 @@ const StyledRadio = styled.input`
     + span {
       transition: all 200ms;
     }
-    &:hover + span {
-      background-color: ${theme.colors.gray100};
-    }
 
-    &:checked + span {
-      background-color: ${theme.colors.gray900};
-      color: ${theme.colors.white};
+    &:enabled {
+      &:hover + span {
+        background-color: ${theme.colors.gray100};
+      }
 
-      &:hover {
-        background-color: ${theme.colors.gray700};
+      &:checked + span {
+        background-color: ${theme.colors.gray900};
+        color: ${theme.colors.white};
+
+        &:hover {
+          background-color: ${theme.colors.gray700};
+        }
       }
     }
-
-    &:disabled {
-      background-color: aqua;
-    }
   `}
+
+  &:disabled + span {
+    pointer-events: none;
+  }
 `;
 
 export default RadioItem;

--- a/src/components/domain/DatePicker/DateItem.tsx
+++ b/src/components/domain/DatePicker/DateItem.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { Text } from "@components/base";

--- a/src/components/domain/SlotPicker/index.tsx
+++ b/src/components/domain/SlotPicker/index.tsx
@@ -2,7 +2,10 @@ import { ChangeEvent } from "react";
 import { Radio } from "@components/base";
 import type { SlotValueUnion, SlotKeyUnion } from "./types";
 
-const slotItems: { value: SlotKeyUnion; text: SlotValueUnion }[] = [
+export const slotItems: {
+  value: SlotKeyUnion;
+  text: SlotValueUnion;
+}[] = [
   {
     value: "dawn",
     text: "새벽",
@@ -24,6 +27,7 @@ const slotItems: { value: SlotKeyUnion; text: SlotValueUnion }[] = [
 interface SlotPickerProps {
   selectedSlot: SlotKeyUnion;
   className?: string;
+  currentDateTimeSlot: SlotKeyUnion | null;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -31,15 +35,21 @@ const SlotPicker: React.FC<SlotPickerProps> = ({
   selectedSlot,
   className,
   onChange,
+  currentDateTimeSlot,
 }) => {
+  const limit = slotItems.findIndex(
+    ({ value }) => value === currentDateTimeSlot
+  );
+
   return (
     <Radio.Group onChange={onChange} className={className}>
-      {slotItems.map(({ text, value }) => (
+      {slotItems.map(({ text, value }, index) => (
         <Radio.Item
           key={value}
           text={text}
           value={value}
           checked={selectedSlot === value}
+          disabled={index < limit}
         />
       ))}
     </Radio.Group>

--- a/src/components/domain/TimeTable/TimeBlockUnits/ActionTimeBlockUnit.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/ActionTimeBlockUnit.tsx
@@ -7,12 +7,14 @@ const ActionTimeBlockUnit: React.FC<ActionTimeBlockUnitProps> = ({
   rowRef,
   previous,
   next,
+  disabled,
 }) => (
   <S.TimeBlockUnitWrapper
     height={height}
     isEven={next}
     previous={previous}
     next={next}
+    disabled={disabled}
   >
     {next ? (
       <S.HourColumn className="time-block__hour">
@@ -29,9 +31,11 @@ const ActionTimeBlockUnit: React.FC<ActionTimeBlockUnitProps> = ({
         alignItems: "center",
       }}
     >
-      <S.NavigationBlock>
-        {previous ? "전 날 예약 보기" : "다음 날 예약보기"}
-      </S.NavigationBlock>
+      {!disabled && (
+        <S.NavigationBlock>
+          {previous ? "전 날 예약 보기" : "다음 날 예약보기"}
+        </S.NavigationBlock>
+      )}
     </S.FourSixthColumn>
     <S.VerticalDivider />
     <S.OneSixthColumn className="time-block__action" />

--- a/src/components/domain/TimeTable/TimeBlockUnits/TimeBlockUnit.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/TimeBlockUnit.tsx
@@ -64,7 +64,7 @@ const TimeBlockUnit: React.FC<TimeBlockUnitProps> = ({
       <S.VerticalDivider />
       <S.BallColumn className="time-block__ball">
         {status !== "none" && (
-          <Text strong size={30}>
+          <Text strong size={30} style={{ color: "inherit" }}>
             {ballCount !== 0 ? ballCount : "😭"}
           </Text>
         )}

--- a/src/components/domain/TimeTable/TimeBlockUnits/TimeBlockUnit.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/TimeBlockUnit.tsx
@@ -24,6 +24,7 @@ const TimeBlockUnit: React.FC<TimeBlockUnitProps> = ({
   hasReservation,
   onClickStatusBlock,
   step,
+  disabled,
 }) => {
   const isEven = index % 2 === 0;
   const hasBlackTopBorder = index % MAJOR_TIME_BLOCK_UNIT === 0;
@@ -42,6 +43,7 @@ const TimeBlockUnit: React.FC<TimeBlockUnitProps> = ({
       isEven={isEven}
       hasBlackTopBorder={hasBlackTopBorder}
       hasBlackBottomBorder={hasBlackBottomBorder}
+      disabled={disabled}
     >
       <S.HourColumn className="time-block__hour">
         {isEven ? <Hour hour={index / 2} /> : <S.HoursHorizontalDivider />}

--- a/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
@@ -37,9 +37,9 @@ const TimeBlockUnitWrapper = styled.div<TimeBlockUnitWrapperProps>`
   display: flex;
   height: ${({ height }) => `${height}px`};
 
-  ${({ isEven, hasBlackTopBorder, hasBlackBottomBorder }) => {
-    const black = "black";
-    const transparentBlack = "rgb(0 0 0 / 0.2)";
+  ${({ isEven, hasBlackTopBorder, hasBlackBottomBorder, theme }) => {
+    const black = theme.colors.gray900;
+    const transparentBlack = "rgb(135 135 135 / 0.2)";
     const topBorderColor = hasBlackTopBorder ? black : transparentBlack;
     const bottomBorderColor = hasBlackBottomBorder ? black : transparentBlack;
 
@@ -69,19 +69,19 @@ const TimeBlockUnitWrapper = styled.div<TimeBlockUnitWrapperProps>`
         `;
   }}
 
-  ${({ previous }) =>
+  ${({ previous, theme }) =>
     previous &&
     css`
       & .time-block__action {
-        box-shadow: 0 -4px 0 black inset;
+        box-shadow: 0 -4px 0 ${theme.colors.gray900} inset;
       }
     `}
 
-    ${({ next }) =>
+    ${({ next, theme }) =>
     next &&
     css`
       & .time-block__action {
-        box-shadow: 0 4px 0 black inset;
+        box-shadow: 0 4px 0 ${theme.colors.gray900} inset;
       }
     `}
   
@@ -91,6 +91,10 @@ const TimeBlockUnitWrapper = styled.div<TimeBlockUnitWrapperProps>`
       background-color: ${theme.colors.gray400};
       color: ${theme.colors.gray500};
       pointer-events: none;
+
+      & .time-block__status {
+        filter: grayscale(100%);
+      }
     `}
 `;
 

--- a/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
@@ -84,6 +84,14 @@ const TimeBlockUnitWrapper = styled.div<TimeBlockUnitWrapperProps>`
         box-shadow: 0 4px 0 black inset;
       }
     `}
+  
+  ${({ disabled, theme }) =>
+    disabled &&
+    css`
+      background-color: ${theme.colors.gray400};
+      color: ${theme.colors.gray500};
+      pointer-events: none;
+    `}
 `;
 
 const HoursHorizontalDivider = styled.div`

--- a/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
+++ b/src/components/domain/TimeTable/TimeBlockUnits/style.tsx
@@ -103,7 +103,7 @@ const HoursHorizontalDivider = styled.div`
   height: 2px;
   width: 20%;
   top: -1px;
-  background-color: black;
+  background-color: ${({ theme }) => theme.colors.gray900};
   opacity: 0.08;
 `;
 
@@ -129,7 +129,7 @@ const BallColumn = styled(OneSixthColumn)`
 const VerticalDivider = styled.div`
   width: 8px;
   height: 100%;
-  background-color: black;
+  background-color: ${({ theme }) => theme.colors.gray900};
 `;
 
 const Selector = styled.div<any>`
@@ -139,7 +139,7 @@ const Selector = styled.div<any>`
   width: 100%;
   height: 100%;
   color: white;
-  background-color: black;
+  background-color: ${({ theme }) => theme.colors.gray900};
   border-radius: 16px;
   border: 8px solid ${({ theme }) => theme.colors.slam.orange.strong};
   box-sizing: border-box;
@@ -160,7 +160,7 @@ const ReservationMarker = styled.div<any>`
     height: ${height}px;
     border: ${selected && "8px solid orange"};
   `};
-  background-color: black;
+  background-color: ${({ theme }) => theme.colors.gray900};
   color: white;
   border-radius: 16px;
   box-sizing: border-box;

--- a/src/components/domain/TimeTable/TimeRangeSelector/index.tsx
+++ b/src/components/domain/TimeTable/TimeRangeSelector/index.tsx
@@ -27,7 +27,7 @@ const RangeSelector: React.FC<Props> = ({ unit, startIndex, endIndex }) => {
               top: unit * (startIndex + 1) - 3,
               height: unit * (endIndex + 2) - unit * (startIndex + 1) + 6,
               width: 8,
-              backgroundColor: "black",
+              backgroundColor: "#262625",
             }}
           ></div>
           <div
@@ -37,7 +37,7 @@ const RangeSelector: React.FC<Props> = ({ unit, startIndex, endIndex }) => {
               top: unit * (startIndex + 1) - 3,
               height: unit * (endIndex + 2) - unit * (startIndex + 1) + 6,
               width: 8,
-              backgroundColor: "black",
+              backgroundColor: "#262625",
             }}
           ></div>
           <S.EndRangeSelector

--- a/src/components/domain/TimeTable/index.tsx
+++ b/src/components/domain/TimeTable/index.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styled from "@emotion/styled";
 
 import { useResize } from "@hooks/.";
 import { Image, Spacer, Text } from "@components/base";
 import { useRouter } from "next/router";
 import useIsomorphicLayoutEffect from "@hooks/useIsomorphicLayoutEffect";
+import { getIndexFromDate } from "@utils/timeTable";
 import { TimeBlockUnit, ActionTimeBlockUnit, Header } from "./TimeBlockUnits";
 import TimeRangeSelector from "./TimeRangeSelector";
 import * as S from "./style";
@@ -17,6 +18,7 @@ const timeSlotIndexMap: { [key in string]: number } = {
 };
 
 const TimeTable = ({
+  isToday,
   timeTable,
   onClickStatusBlock,
   onClickReservationMarker,
@@ -26,6 +28,11 @@ const TimeTable = ({
   existedReservations,
   selectedReservationId,
 }: any) => {
+  const currentTimeIndex = useMemo(
+    () => (isToday ? getIndexFromDate(new Date()) : null),
+    [isToday]
+  );
+
   const {
     query: { timeSlot },
   } = useRouter();
@@ -74,7 +81,12 @@ const TimeTable = ({
     >
       <Header />
       <S.TimeTableContainer>
-        <ActionTimeBlockUnit rowRef={ref} height={height} previous />
+        <ActionTimeBlockUnit
+          rowRef={ref}
+          height={height}
+          previous
+          disabled={isToday}
+        />
         {timeTable.map((item: any, index: number) => (
           <TimeBlockUnit
             key={index}
@@ -86,6 +98,7 @@ const TimeTable = ({
             onClickStatusBlock={onClickStatusBlock}
             selected={startIndex === index}
             step={step}
+            disabled={isToday && currentTimeIndex && index < currentTimeIndex}
           />
         ))}
         {step === 2 && (

--- a/src/components/domain/TimeTable/index.tsx
+++ b/src/components/domain/TimeTable/index.tsx
@@ -98,7 +98,9 @@ const TimeTable = ({
             onClickStatusBlock={onClickStatusBlock}
             selected={startIndex === index}
             step={step}
-            disabled={isToday && currentTimeIndex && index < currentTimeIndex}
+            disabled={
+              isToday && currentTimeIndex && index < currentTimeIndex + 1
+            }
           />
         ))}
         {step === 2 && (

--- a/src/components/domain/TimeTable/style.tsx
+++ b/src/components/domain/TimeTable/style.tsx
@@ -17,8 +17,8 @@ const ReservationMarker = styled.div<any>`
     height: ${height}px;
     border: ${selected && `8px solid ${theme.colors.slam.orange.strong}`};
   `};
-  background-color: black;
-  color: white;
+  background-color: ${({ theme }) => theme.colors.gray900};
+  color: ${({ theme }) => theme.colors.white};
   border-radius: ${({ theme }) => theme.borderRadiuses.lg};
   box-sizing: border-box;
   text-align: center;

--- a/src/components/domain/TimeTable/type.ts
+++ b/src/components/domain/TimeTable/type.ts
@@ -7,6 +7,7 @@ interface TimeBlockUnitWrapperProps {
   isEven?: boolean;
   hasBlackTopBorder?: boolean;
   hasBlackBottomBorder?: boolean;
+  disabled?: boolean;
 }
 
 interface TimeBlockUnitProps extends Pick<TimeBlockUnitWrapperProps, "height"> {
@@ -17,11 +18,13 @@ interface TimeBlockUnitProps extends Pick<TimeBlockUnitWrapperProps, "height"> {
   step: number;
   hasReservation: boolean;
   onClickStatusBlock: (index: number) => void;
+  disabled?: boolean;
 }
 
 interface ActionTimeBlockUnitProps
   extends Pick<TimeBlockUnitWrapperProps, "height" | "previous" | "next"> {
   rowRef?: RefObject<HTMLDivElement>;
+  disabled?: boolean;
 }
 
 interface HourProps {

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -3,6 +3,7 @@ export { default as BottomNavigation } from "./BottomNavigtion";
 export { default as KakaoLogin } from "./KakaoLogin";
 export { default as DatePicker } from "./DatePicker";
 export { default as SlotPicker } from "./SlotPicker";
+export { slotItems } from "./SlotPicker";
 export type { SlotKeyUnion } from "./SlotPicker/types";
 export { default as Favorites } from "./Favorites";
 export { default as TimeTable } from "./TimeTable";

--- a/src/pages/courts/[courtId]/[date].tsx
+++ b/src/pages/courts/[courtId]/[date].tsx
@@ -14,9 +14,10 @@ import {
   weekdays,
   TIME_TABLE_ROWS,
   MAX_RESERVATION_TIME_BLOCK_UNIT,
-  getIndexFromDate,
+  getIndexFromDateString,
   getTimeFromIndex,
   getDatetimeString,
+  getDateStringFromDate,
 } from "@utils/timeTable";
 import { courtApi, reservationApi } from "@service/.";
 
@@ -117,9 +118,9 @@ const getTimeTableInfoFromReservations = (reservations: any, userId: any) => {
   return reservations.reduce(
     (acc: any, reservation: any) => {
       const { existedReservations, timeTable } = acc;
-      const startRow = getIndexFromDate(reservation.startTime);
+      const startRow = getIndexFromDateString(reservation.startTime);
       // TODO: 왜 -1 해야 되더라
-      const endRow = getIndexFromDate(reservation.endTime);
+      const endRow = getIndexFromDateString(reservation.endTime);
       const hasReservation = reservation.userId === userId;
 
       if (hasReservation) {
@@ -552,6 +553,7 @@ const Reservation: NextPage = () => {
   return (
     <div>
       <TimeTable
+        isToday={date === getDateStringFromDate(new Date())}
         timeTable={timeTable || []}
         onClickStatusBlock={
           step === 1 ? handleSetStartIndex : handleSetEndIndex

--- a/src/pages/courts/[courtId]/[date].tsx
+++ b/src/pages/courts/[courtId]/[date].tsx
@@ -526,6 +526,14 @@ const Reservation: NextPage = () => {
   );
 
   useEffect(() => {
+    if (new Date(date as string).getTime() < new Date().getTime()) {
+      // TODO: 과거 예약 정보 링크로 들어올 시 모달로 안내 후 사용자를 /courts로 이동
+      // alert("과거의 예약 정보는 확인할 수 없습니다.");
+      router.replace("/courts");
+    }
+  });
+
+  useEffect(() => {
     setNavigationTitle(<ReservationTitle date={date as string} />);
   }, [date, setNavigationTitle]);
 

--- a/src/pages/courts/index.tsx
+++ b/src/pages/courts/index.tsx
@@ -11,6 +11,7 @@ import {
   SlotPicker,
   BasketballMarker,
   Map,
+  slotItems,
   SlotKeyUnion,
   CourtItem,
 } from "@components/domain";
@@ -74,7 +75,7 @@ const Courts: NextPage = () => {
 
   const { map } = useMapContext();
 
-  const today = useMemo(() => {
+  const currentDate = useMemo(() => {
     const date = new Date();
     date.setHours(0, 0, 0, 0);
 
@@ -86,7 +87,7 @@ const Courts: NextPage = () => {
   const [level, setLevel] = useState<number>(3);
   const [center, setCenter] = useState<Coord>();
 
-  const [selectedDate, setSelectedDate] = useState<Date>(today);
+  const [selectedDate, setSelectedDate] = useState<Date>(currentDate);
   const [selectedSlot, setSelectedSlot] = useState<SlotKeyUnion>(() =>
     getSlotFromDate(new Date())
   );
@@ -178,9 +179,26 @@ const Courts: NextPage = () => {
     setSelectedSlot(e.target.value);
   }, []);
 
-  const handleDateClick = useCallback((selectedDate: Date) => {
-    setSelectedDate(selectedDate);
-  }, []);
+  const handleDateClick = useCallback(
+    (selectedDate: Date) => {
+      if (selectedDate.getTime() === currentDate.getTime()) {
+        const currentSlot = getSlotFromDate(new Date());
+        const selectedSlotIndex = slotItems.findIndex(
+          ({ value }) => value === selectedSlot
+        );
+        const currentSlotIndex = slotItems.findIndex(
+          ({ value }) => value === currentSlot
+        );
+
+        if (selectedSlotIndex < currentSlotIndex) {
+          setSelectedSlot(currentSlot);
+        }
+      }
+
+      setSelectedDate(selectedDate);
+    },
+    [currentDate]
+  );
 
   const handleMarkerClick = useCallback((court: any) => {
     setIsOpen(true);
@@ -215,14 +233,6 @@ const Courts: NextPage = () => {
     }
   }, [map, handleChangedMapBounds]);
 
-  const dateString = useMemo(
-    () =>
-      `${selectedDate.getFullYear()}-${
-        selectedDate.getMonth() + 1
-      }-${selectedDate.getDate()}`,
-    [selectedDate]
-  );
-
   return (
     <>
       <Head>
@@ -230,7 +240,7 @@ const Courts: NextPage = () => {
       </Head>
       <DatePicker
         isBackgroundTransparent={isTopTransparent}
-        startDate={today}
+        startDate={currentDate}
         selectedDate={selectedDate}
         onClick={handleDateClick}
       />
@@ -246,6 +256,11 @@ const Courts: NextPage = () => {
             onGetCurrentLocation={handleGetCurrentLocation}
           />
           <TopFixedSlotPicker
+            currentDateTimeSlot={
+              selectedDate.getTime() === currentDate.getTime()
+                ? getSlotFromDate(new Date())
+                : null
+            }
             selectedSlot={selectedSlot}
             onChange={handleChangeSlot}
           />

--- a/src/pages/courts/index.tsx
+++ b/src/pages/courts/index.tsx
@@ -197,7 +197,7 @@ const Courts: NextPage = () => {
 
       setSelectedDate(selectedDate);
     },
-    [currentDate]
+    [currentDate, selectedSlot]
   );
 
   const handleMarkerClick = useCallback((court: any) => {

--- a/src/service/reservationApi.ts
+++ b/src/service/reservationApi.ts
@@ -1,9 +1,5 @@
 import { request, authRequest, authFileRequest } from "./fetcher";
 
-// request: 토큰이 필요없는 익명사용자도 보낼 수 있는 요청
-// authRequest: 토큰이 필요한 사용자가 보낼수잇는요청
-// authFileRequest: 토큰이 필요한 파일 요청
-
 interface IReservation {
   courtId: number;
   startTime: string;

--- a/src/utils/timeTable.ts
+++ b/src/utils/timeTable.ts
@@ -15,13 +15,23 @@ export const getTimeFromIndex = (index: number) => {
   return index % 2 === 0 ? `${startHours}:00` : `${startHours}:30`;
 };
 
-export const getIndexFromDate = (dateString: string) => {
+export const getIndexFromDateString = (dateString: string | Date) => {
   const date = new Date(dateString);
   const hours = date.getHours();
   const minutes = date.getMinutes();
 
   return hours * 2 + (minutes === MINUTES_PER_TIME_BLOCK ? 1 : 0);
 };
+
+export const getIndexFromDate = (date: Date) => {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  return hours * 2 + (minutes >= MINUTES_PER_TIME_BLOCK ? 1 : 0);
+};
+
+export const getDateStringFromDate = (date: Date) =>
+  `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 
 export const getDatetimeString = (dateString: string, index: number) => {
   const date = new Date(`${dateString} ${getTimeFromIndex(index)}`);


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
- 지도뷰에서 오늘 날짜인 경우 시간대를 현재 시간대 이전 시간대를 선택할 수 없도록 합니다.
- 예약 현황 페이지에서 오늘 날짜인 경우 현재 시간대 이전 시간대 정보확인 불가, 예약 불가 하도록 합니다.
## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- 과거 날짜의 예약 현황 조회시 막는 기능은 더미로만 구현해놓았습니다. 후에 모달로 대체할 예정입니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
<img width="641" alt="Screen Shot 2021-12-20 at 4 12 11 AM" src="https://user-images.githubusercontent.com/68159627/146687668-4b595f29-0104-440d-9923-c4e75706893b.png">

