### PR TITLE
하단 네비게이션 관리자 버튼 추가 #144

### DIFF
--- a/src/components/domain/BottomNavigtion/NavIcon/index.tsx
+++ b/src/components/domain/BottomNavigtion/NavIcon/index.tsx
@@ -1,0 +1,28 @@
+import { Icon } from "@components/base";
+import { FeatherIconNameType } from "@components/base/Icon";
+import { useNavigationContext } from "@contexts/hooks";
+import { PageTypeUnion } from "@contexts/NavigationProvider/actionTypes";
+import Link from "next/link";
+
+interface Props {
+  href: string;
+  iconName: FeatherIconNameType;
+  pageType: PageTypeUnion;
+}
+
+const NavIcon = ({ href, iconName, pageType }: Props) => {
+  const { navigationProps } = useNavigationContext();
+  const { currentPage } = navigationProps;
+
+  return (
+    <Link href={href} key={href} passHref>
+      <Icon
+        name={iconName}
+        size={24}
+        color={currentPage === pageType ? "black" : "#cfcfcf"}
+      />
+    </Link>
+  );
+};
+
+export default NavIcon;

--- a/src/components/domain/BottomNavigtion/index.tsx
+++ b/src/components/domain/BottomNavigtion/index.tsx
@@ -1,54 +1,39 @@
 import styled from "@emotion/styled";
 import React from "react";
-import Link from "next/link";
-import { Icon } from "@components/base";
-import { useNavigationContext } from "@contexts/hooks";
+import { useAuthContext } from "@contexts/hooks";
+import { pageType } from "@contexts/NavigationProvider/actionTypes";
+import NavIcon from "./NavIcon";
 
 const BottomNavigation = () => {
-  const {
-    navigationProps: { currentPage },
-    pageType,
-  } = useNavigationContext();
-
-  const navIcons = [
-    {
-      href: "/",
-      name: "star",
-      isCurrentPage: currentPage === pageType.FAVORITES,
-    },
-    {
-      href: "/courts",
-      name: "compass",
-      isCurrentPage: currentPage === pageType.MAP,
-    },
-    {
-      href: "/reservations",
-      name: "calendar",
-      isCurrentPage: currentPage === pageType.RESERVATIONS,
-    },
-
-    // TODO: 2순위: 팔로우한 사용자들의 예약 알기 탭
-    // {
-    //   href: "/activity",
-    //   name: "users",
-    //   isCurrentPage: currentPage === pageType.ACTIVITY,
-    // },
-  ] as const;
+  const { authProps } = useAuthContext();
+  const { role } = authProps.currentUser;
 
   return (
     <Container>
       <Wrapper>
-        {navIcons.map(({ href, name, isCurrentPage }) => (
-          <Link href={href} key={href}>
-            <a>
-              <Icon
-                name={name}
-                size={24}
-                color={isCurrentPage ? "black" : "#cfcfcf"}
-              />
-            </a>
-          </Link>
-        ))}
+        <NavIcon href={"/"} iconName={"star"} pageType={pageType.FAVORITES} />
+        <NavIcon
+          href={"/courts"}
+          iconName={"compass"}
+          pageType={pageType.MAP}
+        />
+        <NavIcon
+          href={"/reservations"}
+          iconName={"calendar"}
+          pageType={pageType.RESERVATIONS}
+        />
+        {/* <NavIcon
+          href={"/activity"}
+          iconName={"users"}
+          pageType={pageType.ACTIVITY}
+        /> */}
+        {role === "ADMIN" && (
+          <NavIcon
+            href={"/admin/newcourts"}
+            iconName={"check-square"}
+            pageType={pageType.ADMIN_NEWCOURTS}
+          />
+        )}
       </Wrapper>
     </Container>
   );

--- a/src/contexts/AuthProvider/reducer.ts
+++ b/src/contexts/AuthProvider/reducer.ts
@@ -1,13 +1,13 @@
 import { Reducer } from "react";
 import { authTypes, ActionTypeUnion } from "./actionTypes";
-import { Follow, Favorite, Notification, Reservation } from "./types";
+import { Follow, Favorite, Notification, Reservation, Role } from "./types";
 
 export interface DataProps {
   currentUser: {
     userId: number | null;
     email: string | null;
     profileImageUrl: string | null;
-    role: string | null;
+    role: Role | null;
     description: string | null;
     nickname: string | null;
     favorites: Favorite[];

--- a/src/contexts/AuthProvider/types.ts
+++ b/src/contexts/AuthProvider/types.ts
@@ -1,5 +1,7 @@
 import { PositionKeyUnion, ProficiencyKeyUnion } from "@components/domain";
 
+export type Role = "USER" | "ADMIN";
+
 export type Follow = {
   followId: number;
   followerId: number;


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
관리자를 위한 하단 네비게이션 관리자 버튼 추가 했습니다.
AuthContext.Provider에서 뿌려주는 authProps.currentUser.role이 "ADMIN"인 경우
관리자 버튼을 보실 수 있게 됩니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
#144

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/146688220-6d6bd92a-d63c-4443-8e99-b416879c9e1f.png)

## 추후 보완 해야할 부분
- ADMIN이 아니면 이 페이지에 들어 올 수 없도록 라우트 가드 처리
