### PR TITLE
✨ feat: 익명 유저 탐색 페이지에서 추가 또는 예약 시도 시 로그인 유도하기

### DIFF
--- a/src/components/domain/LeadToLoginModal/index.tsx
+++ b/src/components/domain/LeadToLoginModal/index.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@components/base";
+import { ReactNode } from "react";
+import Modal from "../Modal";
+
+interface Props {
+  headerContent: ReactNode;
+  isOpen: boolean;
+  cancel: {
+    content: ReactNode;
+    handle: () => void;
+  };
+  confirm: {
+    content: ReactNode;
+    handle: () => void;
+  };
+}
+
+const LeadToLoginModal = ({
+  headerContent,
+  isOpen,
+  cancel,
+  confirm,
+}: Props) => (
+  <Modal visible={isOpen} onClose={cancel.handle}>
+    <Modal.Header>{headerContent}</Modal.Header>
+    <Modal.BottomButtonContainer>
+      <Button style={{ flex: 1 }} secondary size="lg" onClick={cancel.handle}>
+        {cancel.content}
+      </Button>
+      <Button style={{ flex: 1 }} size="lg" onClick={confirm.handle}>
+        {confirm.content}
+      </Button>
+    </Modal.BottomButtonContainer>
+  </Modal>
+);
+
+export default LeadToLoginModal;

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -30,6 +30,7 @@ export type {
 export { default as ValidationNoticeBar } from "./ValidationNoticeBar";
 export { default as NoItemMessage } from "./NoItemMessage";
 export { default as ProfileFavoritesListItem } from "./ProfileFavoritesListItem";
+export { default as LeadToLoginModal } from "./LeadToLoginModal";
 // eslint-disable-next-line import/no-cycle
 export { default as NotificationList } from "./NotificationList";
 

--- a/src/pages/courts/index.tsx
+++ b/src/pages/courts/index.tsx
@@ -3,6 +3,7 @@ import { NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import styled from "@emotion/styled";
+import { useLocalToken } from "@hooks/domain";
 
 import { getCurrentLocation } from "@utils/geolocation";
 import { Button, ModalSheet, Spacer, Text } from "@components/base";
@@ -14,6 +15,7 @@ import {
   slotItems,
   SlotKeyUnion,
   CourtItem,
+  LeadToLoginModal,
 } from "@components/domain";
 import { useMapContext, useNavigationContext } from "@contexts/hooks";
 import { useRouter } from "next/router";
@@ -66,12 +68,10 @@ const Courts: NextPage = () => {
   } = useNavigationContext();
 
   const { isTopTransparent } = navigationProps;
+  const [localToken] = useLocalToken();
 
   useMountPage((page) => page.MAP);
   useDisableTopTransparent();
-  useMountCustomButtonEvent("추가", () => {
-    router.push("/courts/create");
-  });
 
   const { map } = useMapContext();
 
@@ -95,7 +95,19 @@ const Courts: NextPage = () => {
   // TODO: API 명세 나올 경우 any 수정해주기
   const [selectedCourt, setSelectedCourt] = useState<any>(null);
   const [isAddressLoading, setIsAddressLoading] = useState<boolean>(false);
+
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpenLeadToLoginModal, setIsOpenLeadToLoginModal] =
+    useState<boolean>(false);
+
+  useMountCustomButtonEvent("추가", () => {
+    if (localToken) {
+      router.push("/courts/create");
+    } else {
+      setIsOpenLeadToLoginModal(true);
+    }
+  });
+
   const [snap, setSnap] = useState<number>(1);
 
   const onClose = useCallback(() => {
@@ -299,24 +311,33 @@ const Courts: NextPage = () => {
                 longitude={selectedCourt.longitude}
                 courtName={selectedCourt.courtName}
               />
-              <Link
-                href={{
-                  pathname: `/courts/[courtId]/[date]`,
-                  query: {
-                    timeSlot: selectedSlot,
-                  },
-                }}
-                as={`/courts/${
-                  selectedCourt.courtId
-                }/${selectedDate.getFullYear()}-${
-                  selectedDate.getMonth() + 1
-                }-${selectedDate.getDate()}`}
-                passHref
-              >
-                <Button style={{ flex: 1 }} size="lg">
-                  예약하기
-                </Button>
-              </Link>
+
+              {localToken ? (
+                <Link
+                  href={{
+                    pathname: `/courts/[courtId]/[date]`,
+                    query: {
+                      timeSlot: selectedSlot,
+                    },
+                  }}
+                  as={`/courts/${
+                    selectedCourt.courtId
+                  }/${selectedDate.getFullYear()}-${
+                    selectedDate.getMonth() + 1
+                  }-${selectedDate.getDate()}`}
+                  passHref
+                >
+                  <Button style={{ flex: 1 }} size="lg">
+                    예약하기
+                  </Button>
+                </Link>
+              ) : (
+                <Link href={"/login"} passHref>
+                  <Button style={{ flex: 1 }} size="lg">
+                    로그인하고 예약하기
+                  </Button>
+                </Link>
+              )}
             </Actions>
 
             {snap === 0 ? (
@@ -339,6 +360,23 @@ const Courts: NextPage = () => {
           </ModalContentContainer>
         )}
       </ModalSheet>
+
+      <LeadToLoginModal
+        headerContent={"로그인하면 새 농구장을 추가할 수 있습니다"}
+        isOpen={isOpenLeadToLoginModal}
+        cancel={{
+          content: "닫기",
+          handle: () => {
+            setIsOpenLeadToLoginModal(false);
+          },
+        }}
+        confirm={{
+          content: "로그인하러 가기",
+          handle: () => {
+            router.push("/login");
+          },
+        }}
+      />
     </>
   );
 };


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->

closes #134

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->

- 추가 버튼 눌렀을 때 모달창 띄우기
  - `로그인하러 가기`누르면 로그인 페이지로 이동합니다.
  
- 농구장이 없어서 캡쳐는 못했지만 익명 사용자일 경우 버튼이 
  - `예약 하러가기` ➡️ `로그인하고 예약하기` 로 변경하였고, 로그인 페이지로 이동합니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/33405125/146690285-d0c1c441-1737-4cf1-ae0c-4edb2deea49a.png)
