### PR TITLE
탐색 경유 로그인 유도를 위한 로그인페이지 BottomFixedButton 개선

### DIFF
--- a/src/components/domain/BottomFixedButton/index.tsx
+++ b/src/components/domain/BottomFixedButton/index.tsx
@@ -1,9 +1,11 @@
 import React, { CSSProperties } from "react";
-import type { MouseEvent, ReactNode } from "react";
-import { Button } from "@components/base";
+import type { ReactNode } from "react";
+import { Button, IconButton } from "@components/base";
 import styled from "@emotion/styled";
 import ReactDOM from "react-dom";
 import { css } from "@emotion/react";
+import Link from "next/link";
+import { FeatherIconNameType } from "@components/base/Icon";
 
 interface Props {
   children: ReactNode;
@@ -13,6 +15,12 @@ interface Props {
   className?: string;
   style?: CSSProperties;
   bottom?: number;
+  iconButton?: {
+    icon: FeatherIconNameType;
+    href?: string;
+    onClick?: () => void;
+  };
+  custom?: boolean;
 }
 
 const BottomFixedButton: React.FC<Props> = ({
@@ -23,17 +31,26 @@ const BottomFixedButton: React.FC<Props> = ({
   style,
   className,
   bottom,
+  iconButton,
+  custom = false,
 }) => {
   return typeof document !== "undefined" ? (
     ReactDOM.createPortal(
-      <Background bottom={bottom} style={style}>
+      <Background bottom={bottom} custom={custom}>
+        {iconButton && iconButton.href ? (
+          <Link href={iconButton.href} passHref>
+            <IconButton name={iconButton.icon} />
+          </Link>
+        ) : (
+          iconButton && <IconButton name={iconButton.icon} />
+        )}
         <Button
           type={type}
           disabled={disabled}
-          fullWidth
           onClick={onClick}
           size="lg"
           className={className}
+          style={style}
         >
           {children}
         </Button>
@@ -52,7 +69,7 @@ export const BottomFixedContainer: React.FC = ({
 }: any) =>
   typeof document !== "undefined" ? (
     ReactDOM.createPortal(
-      <Background custom className={className}>
+      <Background custom={custom} className={className}>
         {children}
       </Background>,
       document.querySelector("#scrolled-container")!
@@ -62,6 +79,9 @@ export const BottomFixedContainer: React.FC = ({
   );
 
 const Background = styled.div<Pick<Props, "bottom"> & { custom?: boolean }>`
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
   box-sizing: border-box;
   position: fixed;
   bottom: ${({ bottom }) => (bottom ? `${bottom}px` : 0)};
@@ -74,14 +94,13 @@ const Background = styled.div<Pick<Props, "bottom"> & { custom?: boolean }>`
   max-width: 640px;
 
   button {
-    position: absolute;
     bottom: ${({ theme }) => theme.gaps.base};
   }
   ${({ custom }) =>
     !custom &&
     css`
       button {
-        width: calc(100% - 40px); // 100% - theme.gaps.base * 2
+        width: 100%;
       }
     `}
 `;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,12 +1,11 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import Link from "next/link";
 import UtilRoute from "UtilRoute";
 import { useNavigationContext } from "@contexts/hooks";
 import { useRouter } from "next/router";
 import { BottomFixedButton, Logo } from "@components/domain";
 import styled from "@emotion/styled";
-import { Header, Spacer } from "@components/base";
+import { Spacer } from "@components/base";
 
 const Login: NextPage = UtilRoute("prevented", () => {
   const router = useRouter();
@@ -32,7 +31,12 @@ const Login: NextPage = UtilRoute("prevented", () => {
         <DescriptionText>같이 농구할 사람이 없다고?</DescriptionText>
       </Spacer>
 
-      <KaKaoLoginButton onClick={handleClickLogin}>
+      <KaKaoLoginButton
+        onClick={handleClickLogin}
+        iconButton={{ icon: "map", href: "/courts" }}
+        custom
+        style={{ flex: 1 }}
+      >
         카카오 로그인
       </KaKaoLoginButton>
     </PageContainer>
@@ -56,4 +60,7 @@ const DescriptionText = styled.span`
 const KaKaoLoginButton = styled(BottomFixedButton)`
   background-color: ${({ theme }) => theme.colors.kakao.yellow.strong};
   color: ${({ theme }) => theme.colors.kakao.brown.strong};
+  :hover {
+    background-color: ${({ theme }) => theme.colors.kakao.yellow.middle};
+  }
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -46,6 +46,7 @@ const theme = {
     kakao: {
       yellow: {
         strong: "#F7E600",
+        middle: "#FFF683",
       },
       brown: {
         strong: "#3A1D1D",


### PR DESCRIPTION
## 💁 설명 <!-- 무엇에 대한 PR인지 설명해주세요. -->
탐색으로 경유해 로그인을 유도하기로 결정한 만큼 로그인페이지에서도 탐색페이지로 쉽게 경유하도록 작은 지도 버튼을 만들었습니다.

## 🔗 연결된 이슈 <!-- 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1` -->
#152

## 🚨 PR 포인트 <!-- PR을 볼 때 중점적으로 봐야 할 부분을 적어주세요-->
@grighth12 정희가 만든 BottomFixedButton을 button absolute를 flex:1로 하도록 건드렸습니다.
나름대로 테스트를 돌려봤을 때는 문제 없었지만 사용하신 다른 부분에서 혹시나 영향이 있을까 걱정이 됩니다.

## 📸 스크린 샷 <!-- 구현 내용의 스크린 샷을 첨부해주세요-->
![image](https://user-images.githubusercontent.com/61593290/146694458-0ed60a87-65af-40b0-97d7-a7871b9679aa.png)

